### PR TITLE
Fix/gitlab url schema

### DIFF
--- a/lisp/forge-core.el
+++ b/lisp/forge-core.el
@@ -220,9 +220,9 @@ at that time."
 
 (cl-defmethod forge--split-url-path
   ((_class (subclass forge-repository)) path)
-  (and (string-match "\\`\\([^/]+\\)/\\([^/]+?\\)\\'" path)
+  (and (string-match "\\`\\([^/]+\\)/\\(.+?\\)\\'" path)
        (list (match-string 1 path)
-             (match-string 2 path))))
+             (replace-regexp-in-string "/" "%2F" (match-string 2 path)))))
 
 (cl-defmethod forge--split-url-path
   ((_class (subclass forge-noapi-repository)) path)

--- a/lisp/forge-core.el
+++ b/lisp/forge-core.el
@@ -200,7 +200,7 @@ at that time."
     (user-error "Cannot browse non-forge remote %s" remote)))
 
 (defun forge--url-regexp ()
-  (concat "\\`\\(?:git://\\|git@\\|teahub@\\|ssh://git@\\|https://\\)"
+  (concat "\\`\\(?:git://\\|git@\\|gitlab@\\|teahub@\\|ssh://git@\\|https://\\)"
           (regexp-opt (mapcar #'car forge-alist) t)
           "[:/]\\(.+?\\)"
           "\\(?:\\.git\\)?\\'"))


### PR DESCRIPTION
This PR does 2 things:

1. Add `gitlab@` as a valid prefix to `forge--url-regexp`
2. Support multi-level groups path for gitlab. But the fix for this is a dirty hack. i need some guidance about how to clean it up

Thanks!