### PR TITLE
forge.el: Add missing 'Keywords' and 'Homepage'

### DIFF
--- a/lisp/forge.el
+++ b/lisp/forge.el
@@ -5,6 +5,9 @@
 ;; Author: Jonas Bernoulli <jonas@bernoul.li>
 ;; Maintainer: Jonas Bernoulli <jonas@bernoul.li>
 
+;; Keywords: git tools vc
+;; Homepage: https://github.com/magit/forge
+
 ;; Magit is free software; you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation; either version 3, or (at your option)


### PR DESCRIPTION
Maybe 'Keywords' should have 'github' and 'gitlab'