### PR TITLE
fix #33 - github 422 when creating pull request from fork

### DIFF
--- a/lisp/forge-github.el
+++ b/lisp/forge-github.el
@@ -380,7 +380,7 @@ repositories.
                           (base  . ,base-branch)
                           (head  . ,(if (equal head-remote base-remote)
                                         head-branch
-                                      (concat (oref repo name) ":" head-branch)))
+                                      (concat (oref (forge-get-repository 'stub head-remote) owner) ":" head-branch)))
                           (maintainer_can_modify . t))
                         :callback  (forge--post-submit-callback)
                         :errorback (forge--post-submit-errorback)))))


### PR DESCRIPTION
- fix usage of incorrect owner for head (was using base owner)
  (see https://developer.github.com/v3/pulls/#create-a-pull-request)