### PR TITLE
Correct username handling for ssh URLs in `forge--url-regexp'

### DIFF
--- a/lisp/forge-core.el
+++ b/lisp/forge-core.el
@@ -207,7 +207,7 @@ at that time."
     (user-error "Cannot browse non-forge remote %s" remote)))
 
 (defun forge--url-regexp ()
-  (concat "\\`\\(?:git://\\|git@\\|teahub@\\|ssh://git@\\|https://\\)"
+  (concat "\\`\\(?:git://\\|git@\\|teahub@\\|ssh://\\(?:[a-zA-Z0-9-]*@\\)*\\|https://\\)"
           (regexp-opt (mapcar #'car forge-alist) t)
           "[:/]\\(.+?\\)"
           "\\(?:\\.git\\)?\\'"))


### PR DESCRIPTION
The git-clone(1) man page states that ssh git urls should follow

ssh://[user@]host.xz[:port]/path/to/repo.git/

Make the username part optional and allow usernames other than `git'.
The supplied regexp should match all allowed github usernames, but is
not very strict.