### PR TITLE
Display inline images in topics

### DIFF
--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -334,7 +334,10 @@ identifier."
             (add-face-text-property 0 (length heading)
                                     'magit-diff-hunk-heading t heading)
             (magit-insert-heading heading))
-          (insert (forge--fontify-markdown body) "\n\n"))))))
+          (insert (forge--fontify-markdown body) "\n\n"))))
+    (when (fboundp 'markdown-display-inline-images)
+      (let ((markdown-display-remote-images t))
+        (markdown-display-inline-images)))))
 
 (defvar forge-topic-title-section-map
   (let ((map (make-sparse-keymap)))


### PR DESCRIPTION
Implement the view-parts of #41.

This is still something of a proof-of-concept and is dependent on jrblevin/markdown-mode#378. Make sure you set `markdown-display-remote-images` to `t` (it could be let-bound to a Forge-customization here) and that all appropriate protocols have been added to `markdown-remote-image-protocols`.