### PR TITLE
Bind RET to follow Markdown links in issue buffers

### DIFF
--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -205,6 +205,7 @@ The following %-sequences are supported:
     (define-key map (kbd "C-c C-n") 'forge-create-post)
     (define-key map (kbd "C-c C-r") 'forge-create-post)
     (define-key map [remap magit-browse-thing] 'forge-browse-topic)
+    (define-key map [remap magit-visit-thing] 'markdown-follow-link-at-point)
     map))
 
 (define-derived-mode forge-topic-mode magit-mode "View Topic"


### PR DESCRIPTION
* `lisp/forge-topic.el` (`forge-topic-mode-map`): Remap `magit-visit-thing` to `markdown-follow-link-at-point`.