### PR TITLE
Add "Forge" to magit-dispatch-popup

### DIFF
--- a/lisp/forge.el
+++ b/lisp/forge.el
@@ -61,6 +61,8 @@
 (magit-add-section-hook 'magit-status-sections-hook 'forge-insert-issues   nil t)
 
 (define-key magit-mode-map "'" 'forge-dispatch)
+(magit-define-popup-action 'magit-dispatch-popup
+  ?' "Forge" 'forge-dispatch ?%)
 
 (define-key magit-commit-section-map [remap magit-browse-thing] 'forge-browse-dwim)
 (define-key magit-remote-section-map [remap magit-browse-thing] 'forge-browse-remote)


### PR DESCRIPTION
For users who forget the `forge-dispatch` key, it is helpful to
include it in `magit-dispatch-popup`.