### PR TITLE
Bind forge-list-visit-* in forge-*-list-mode-map w/ magit convention

### DIFF
--- a/lisp/forge-list.el
+++ b/lisp/forge-list.el
@@ -56,7 +56,10 @@
 (defvar forge-issue-list-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map forge-topic-list-mode-map)
-    (define-key map [return] 'forge-list-visit-issue)
+    (cond ((featurep 'jkl)
+           (define-key map [return]    'forge-list-visit-issue))
+          (t
+           (define-key map (kbd "C-m") 'forge-list-visit-issue)))
     map)
   "Local keymap for Forge-Issue-List mode buffers.")
 
@@ -69,7 +72,10 @@
 (defvar forge-pullreq-list-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map forge-topic-list-mode-map)
-    (define-key map [return] 'forge-list-visit-pullreq)
+    (cond ((featurep 'jkl)
+           (define-key map [return]    'forge-list-visit-pullreq))
+          (t
+           (define-key map (kbd "C-m") 'forge-list-visit-pullreq)))
     map)
   "Local keymap for Forge-Pullreq-List mode buffers.")
 


### PR DESCRIPTION
Follow the convention established by magit for `magit-visit-thing`;
this allows a terminal client to visit topics in a topic list mode
with `RET`, just as commits, topics, etc. can be visited with `RET` in
a magit-mode.

See magit/magit@f629795 for a description of the jkl feature.