### PR TITLE
Generalize browse, visit commands and introduce copy-URL command

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,8 @@
 
 - Added support for issue and pull-request templates.  #25
 
+- Added the command ~forge-copy-url-at-point-as-kill~.  #85
+
 - When visiting an unmerged pull-request in a separate buffer, then
   the commits are now listed alongside the posts.  caeb8fb
 

--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -249,26 +249,20 @@ Prefer a topic over a branch and that over a commit."
   "View the topic at point in a separate buffer."
   (interactive)
   (if-let ((topic (forge-topic-at-point)))
-      (if (forge-issue-p topic)
-          (forge-visit-issue topic)
-        (forge-visit-pullreq topic))
+      (forge-visit topic)
     (user-error "There is no topic at point")))
 
 ;;;###autoload
 (defun forge-visit-pullreq (pullreq)
   "View the pull-request at point in a separate buffer."
   (interactive (list (forge-read-pullreq "View pull-request" t)))
-  (let ((magit-generate-buffer-name-function 'forge-topic-buffer-name))
-    (magit-mode-setup-internal #'forge-topic-mode (list pullreq) t))
-  (oset pullreq unread-p nil))
+  (forge-visit pullreq))
 
 ;;;###autoload
 (defun forge-visit-issue (issue)
   "View the issue at point in a separate buffer."
   (interactive (list (forge-read-issue "View issue" t)))
-  (let ((magit-generate-buffer-name-function 'forge-topic-buffer-name))
-    (magit-mode-setup-internal #'forge-topic-mode (list issue) t))
-  (oset issue unread-p nil))
+  (forge-visit issue))
 
 ;;; Create
 

--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -239,8 +239,9 @@ Prefer a topic over a branch and that over a commit."
 (defun forge-browse-post ()
   "Visit the url corresponding to the post at point using a browser."
   (interactive)
-  (when-let ((post (forge-post-at-point)))
-    (forge-browse post)))
+  (if-let ((post (forge-post-at-point)))
+      (forge-browse post)
+    (user-error "There is no post at point")))
 
 ;;; Visit
 

--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -183,6 +183,17 @@ Prefer a topic over a branch and that over a commit."
                         `((?r . ,(magit-commit-p rev)))))))
 
 ;;;###autoload
+(defun forge-copy-url-at-point-as-kill ()
+  "Copy the url of the thing at point."
+  (interactive)
+  (if-let ((url (forge-get-url (or (forge-post-at-point)
+                                   (forge-current-topic)))))
+      (progn
+        (kill-new url)
+        (message "Copied %S" url))
+    (user-error "Nothing at point with a URL")))
+
+;;;###autoload
 (defun forge-browse-branch (branch)
   "Visit the url corresponding BRANCH using a browser."
   (interactive (list (magit-read-branch "Browse branch")))

--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -148,9 +148,7 @@ have to do so.  See https://platform.github.community/t/7284."
 Prefer a topic over a branch and that over a commit."
   (interactive)
   (if-let ((topic (forge-topic-at-point)))
-      (if (forge-issue-p topic)
-          (forge-browse-issue topic)
-        (forge-browse-pullreq topic))
+      (forge-browse topic)
     (if-let ((branch (magit-branch-at-point)))
         (forge-browse-branch branch)
       (call-interactively 'forge-browse-commit))))
@@ -210,9 +208,7 @@ Prefer a topic over a branch and that over a commit."
   "Visit the current topic using a browser."
   (interactive)
   (if-let ((topic (forge-current-topic)))
-      (if (forge-issue-p topic)
-          (forge-browse-issue topic)
-        (forge-browse-pullreq topic))
+      (forge-browse topic)
     (user-error "There is no topic at point")))
 
 ;;;###autoload
@@ -225,8 +221,7 @@ Prefer a topic over a branch and that over a commit."
 (defun forge-browse-pullreq (pullreq)
   "Visit the url corresponding to PULLREQ using a browser."
   (interactive (list (forge-read-pullreq "Browse pull-request" t)))
-  (browse-url (forge--format-url pullreq 'pullreq-url-format))
-  (oset pullreq unread-p nil))
+  (forge-browse pullreq))
 
 ;;;###autoload
 (defun forge-browse-issues (repo)
@@ -238,25 +233,14 @@ Prefer a topic over a branch and that over a commit."
 (defun forge-browse-issue (issue)
   "Visit the url corresponding to ISSUE using a browser."
   (interactive (list (forge-read-issue "Browse issue" t)))
-  (browse-url (forge--format-url issue 'issue-url-format))
-  (oset issue unread-p nil))
+  (forge-browse issue))
 
 ;;;###autoload
 (defun forge-browse-post ()
   "Visit the url corresponding to the post at point using a browser."
   (interactive)
-  (let ((post (forge-post-at-point)))
-    (cl-etypecase post
-      (forge-issue   (forge-browse-issue post))
-      (forge-pullreq (forge-browse-pullreq post))
-      (forge-post
-       (let ((topic (forge-get-topic post)))
-         (browse-url
-          (forge--format-url post
-                             (cl-etypecase topic
-                               (forge-issue   'issue-post-url-format)
-                               (forge-pullreq 'pullreq-post-url-format))))
-         (oset topic unread-p nil))))))
+  (when-let ((post (forge-post-at-point)))
+    (forge-browse post)))
 
 ;;; Visit
 

--- a/lisp/forge-core.el
+++ b/lisp/forge-core.el
@@ -174,6 +174,9 @@ argument.")
   "Visit the URL corresponding to a forge object in a browser."
   (browse-url (forge-get-url obj)))
 
+(cl-defgeneric forge-visit (obj)
+  "View a forge object in a separate buffer.")
+
 (cl-defgeneric forge--object-id (class &rest args)
   "Return the database id for the CLASS object specified by ARGS.")
 

--- a/lisp/forge-core.el
+++ b/lisp/forge-core.el
@@ -170,6 +170,10 @@ argument.")
 (cl-defgeneric forge-get-url (obj)
   "Return the URL for a forge object.")
 
+(cl-defgeneric forge-browse (obj)
+  "Visit the URL corresponding to a forge object in a browser."
+  (browse-url (forge-get-url obj)))
+
 (cl-defgeneric forge--object-id (class &rest args)
   "Return the database id for the CLASS object specified by ARGS.")
 

--- a/lisp/forge-core.el
+++ b/lisp/forge-core.el
@@ -167,6 +167,9 @@ argument.")
 (cl-defgeneric forge-get-pullreq ()
   "Return a forge pullreq object.")
 
+(cl-defgeneric forge-get-url (obj)
+  "Return the URL for a forge object.")
+
 (cl-defgeneric forge--object-id (class &rest args)
   "Return the database id for the CLASS object specified by ARGS.")
 

--- a/lisp/forge-issue.el
+++ b/lisp/forge-issue.el
@@ -118,6 +118,9 @@
     (and number
          (forge-get-issue repo number))))
 
+(cl-defmethod forge-get-url ((issue forge-issue))
+  (forge--format-url issue 'issue-url-format))
+
 ;;; Sections
 
 (defun forge-issue-at-point ()

--- a/lisp/forge-notify.el
+++ b/lisp/forge-notify.el
@@ -48,6 +48,11 @@
   (when-let ((id (oref notify repository)))
     (closql-get (forge-db) id 'forge-repository)))
 
+;;; Utilities
+
+(cl-defmethod forge-get-url ((notify forge-notification))
+  (oref notify url))
+
 ;;; Mode
 
 (defvar forge-notifications-mode-map

--- a/lisp/forge-post.el
+++ b/lisp/forge-post.el
@@ -48,6 +48,15 @@
 (cl-defmethod forge-get-repository ((post forge-post))
   (forge-get-repository (forge-get-topic post)))
 
+;;; Utilities
+
+(cl-defmethod forge-get-url ((post forge-post))
+  (forge--format-url post (let ((topic (forge-get-parent post)))
+                            (cond ((forge--childp topic 'forge-issue)
+                                   'issue-post-url-format)
+                                  ((forge--childp topic 'forge-pullreq)
+                                   'pullreq-post-url-format)))))
+
 ;;; Sections
 
 (defun forge-post-at-point ()

--- a/lisp/forge-post.el
+++ b/lisp/forge-post.el
@@ -57,6 +57,9 @@
                                   ((forge--childp topic 'forge-pullreq)
                                    'pullreq-post-url-format)))))
 
+(cl-defmethod forge-browse :after ((post forge-post))
+  (oset (forge-get-topic post) unread-p nil))
+
 ;;; Sections
 
 (defun forge-post-at-point ()

--- a/lisp/forge-pullreq.el
+++ b/lisp/forge-pullreq.el
@@ -183,6 +183,9 @@
     (or (and branch (magit-rev-verify branch) branch)
         (forge--pullreq-ref-1 (oref pullreq number)))))
 
+(cl-defmethod forge-get-url ((pullreq forge-pullreq))
+  (forge--format-url pullreq 'pullreq-url-format))
+
 ;;; Sections
 
 (defun forge-pullreq-at-point ()

--- a/lisp/forge-repo.el
+++ b/lisp/forge-repo.el
@@ -133,8 +133,7 @@ forges and hosts.  "
     (let* ((remotes (magit-list-remotes))
            (remote (or remote
                        (if (cdr remotes)
-                           (car (member (or (magit-get "forge.remote") "origin")
-                                        remotes))
+                           (car (member (forge--get-remote) remotes))
                          (car remotes)))))
       (if-let ((url (and remote (magit-git-string "remote" "get-url" remote))))
           (forge-get-repository url remote demand)
@@ -202,6 +201,9 @@ forges and hosts.  "
   repo)
 
 ;;; Utilities
+
+(defsubst forge--get-remote ()
+  (or (magit-get "forge.remote") "origin"))
 
 (defun forge-read-repository (prompt)
   (let ((choice (magit-completing-read

--- a/lisp/forge-repo.el
+++ b/lisp/forge-repo.el
@@ -245,6 +245,9 @@ forges and hosts.  "
          (?p . ,path)
          (?P . ,(replace-regexp-in-string "/" "%2F" path)))))))
 
+(cl-defmethod forge-get-url ((repo forge-repository))
+  (forge--format-url (oref repo remote) 'remote-url-format))
+
 (defun forge--set-field-callback ()
   (let ((buf (current-buffer)))
     (lambda (&rest _)

--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -144,6 +144,9 @@ The following %-sequences are supported:
               (oref topic repository)
               'forge-repository))
 
+(cl-defmethod forge-get-topic ((topic forge-topic))
+  topic)
+
 (cl-defmethod forge-list-recent-topics ((repo forge-repository) table)
   (let* ((id (oref repo id))
          (limit forge-topic-list-limit)

--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -213,6 +213,13 @@ The following %-sequences are supported:
   (forge--format-url (forge-get-repository topic) slot
                      `(,@spec (?i . ,(oref topic number)))))
 
+(cl-defmethod forge-visit ((topic forge-topic))
+  (let ((magit-generate-buffer-name-function 'forge-topic-buffer-name))
+    (magit-mode-setup-internal #'forge-topic-mode (list topic) t)))
+
+(cl-defmethod forge-visit :after ((topic forge-topic))
+  (oset topic unread-p nil))
+
 (defun forge--sanitize-string (string)
   ;; For Gitlab this may also be nil.
   (if string


### PR DESCRIPTION
Fix #85.

Find in this PR a series of patches that generalizes the existing browse/visit commands and introduce a new command, `forge-copy-url-at-point-as-kill`. I recommend it be bound as `C-c M-w` next to `magit-browse-thing`.

A new method `forge-get-url` is introduced to simplify the function above.  Implementations are provided for issues, pullreqs, posts (to handle comments), repositories, and notifications.  The latter two are unused at this time, but exist for completeness.

At that point, it made sense to redefine `forge-browse-*` in terms of `forge-get-url`.  This is done using another new method, `forge-browse`, where an implementation is added for posts.  The new implementation is decidedly simpler, but perhaps that means I'm missing something here.

And just because the `forge-visit-*` functions then stuck out like sore thumbs, a new method `forge-visit` was provided for those as well -- with a single implementation for posts.  This reduced duplication quite a bit.

Let me know if there are any changes I should make.

I'll note that `forge--remote` was added and used in an incorrect method implementation of `forge-get-url` for `forge-repository` objects. It's only used once again, but I get the feeling it's good to separate out. Since it's not strictly necessary, though, I'll remove it if you so request.

---

I'm thoroughly enjoying working with Forge -- I'm even starting work on a custom `forge-repository` for our home-grown bug-tracking system at work.  It's challenging on that end, but I'm finding Forge well-designed to handle what I throw at it (at least most of it -- our code base is in SVN, so that presents its own troubles).  I may look for help/guidance on that in the future, but I wanted to take this opportunity to say that Forge is a job well done -- I look forward to its continued growth :smile: