### PR TITLE
Provide context when creating posts

### DIFF
--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -179,8 +179,8 @@ Prefer a topic over a branch and that over a commit."
         (message "%s does not appear to be available on any remote.  %s"
                  rev "You might have to push it first.")))
     (browse-url
-     (forge--format-url repo 'commit-url-format
-                        `((?r . ,(magit-commit-p rev)))))))
+     (forge--format repo 'commit-url-format
+                    `((?r . ,(magit-commit-p rev)))))))
 
 ;;;###autoload
 (defun forge-copy-url-at-point-as-kill ()
@@ -205,14 +205,14 @@ Prefer a topic over a branch and that over a commit."
       (or (setq remote (or (magit-get-push-remote branch)
                            (magit-get-upstream-remote branch)))
           (user-error "Cannot determine remote for %s" branch)))
-    (browse-url (forge--format-url remote 'branch-url-format
-                                   `((?r . ,branch))))))
+    (browse-url (forge--format remote 'branch-url-format
+                               `((?r . ,branch))))))
 
 ;;;###autoload
 (defun forge-browse-remote (remote)
   "Visit the url corresponding to REMOTE using a browser."
   (interactive (list (magit-read-remote "Browse remote")))
-  (browse-url (forge--format-url remote 'remote-url-format)))
+  (browse-url (forge--format remote 'remote-url-format)))
 
 ;;;###autoload
 (defun forge-browse-topic ()
@@ -226,7 +226,7 @@ Prefer a topic over a branch and that over a commit."
 (defun forge-browse-pullreqs (repo)
   "Visit the url corresponding to REPO's pull-requests using a browser."
   (interactive (list (forge-get-repository 'stub)))
-  (browse-url (forge--format-url repo 'pullreqs-url-format)))
+  (browse-url (forge--format repo 'pullreqs-url-format)))
 
 ;;;###autoload
 (defun forge-browse-pullreq (pullreq)
@@ -238,7 +238,7 @@ Prefer a topic over a branch and that over a commit."
 (defun forge-browse-issues (repo)
   "Visit the url corresponding to REPO's issues using a browser."
   (interactive (list (forge-get-repository 'stub)))
-  (browse-url (forge--format-url repo 'issues-url-format)))
+  (browse-url (forge--format repo 'issues-url-format)))
 
 ;;;###autoload
 (defun forge-browse-issue (issue)
@@ -309,7 +309,7 @@ Prefer a topic over a branch and that over a commit."
   (let* ((repo (forge-get-repository t))
          (buf (forge--prepare-post-buffer
                "new-pullreq"
-               (forge--format-url repo "Create new pull-request on %p"))))
+               (forge--format repo "Create new pull-request on %p"))))
     (with-current-buffer buf
       (setq forge--buffer-base-branch target)
       (setq forge--buffer-head-branch source)
@@ -323,7 +323,7 @@ Prefer a topic over a branch and that over a commit."
   (let* ((repo (forge-get-repository t))
          (buf (forge--prepare-post-buffer
                "new-issue"
-               (forge--format-url repo "Create new issue on %p"))))
+               (forge--format repo "Create new issue on %p"))))
     (with-current-buffer buf
       (setq forge--buffer-post-object repo)
       (setq forge--submit-post-function 'forge--submit-create-issue))
@@ -334,8 +334,8 @@ Prefer a topic over a branch and that over a commit."
   (interactive)
   (let* ((topic (car magit-refresh-args))
          (buf (forge--prepare-post-buffer
-               (forge--format-url topic "%i:new-comment")
-               (forge--format-url topic "New comment on #%i of %p"))))
+               (forge--format topic "%i:new-comment")
+               (forge--format topic "New comment on #%i of %p"))))
     (with-current-buffer buf
       (setq forge--buffer-post-object topic)
       (setq forge--submit-post-function 'forge--submit-create-post))
@@ -350,12 +350,12 @@ Prefer a topic over a branch and that over a commit."
          (buf (cl-typecase post
                 (forge-topic
                  (forge--prepare-post-buffer
-                  (forge--format-url post "%i")
-                  (forge--format-url post "Edit #%i of %p")))
+                  (forge--format post "%i")
+                  (forge--format post "Edit #%i of %p")))
                 (forge-post
                  (forge--prepare-post-buffer
-                  (forge--format-url post "%i:%I")
-                  (forge--format-url post "Edit comment on #%i of %p"))))))
+                  (forge--format post "%i:%I")
+                  (forge--format post "Edit comment on #%i of %p"))))))
     (with-current-buffer buf
       (setq forge--buffer-post-object post)
       (setq forge--submit-post-function 'forge--submit-edit-post)

--- a/lisp/forge-core.el
+++ b/lisp/forge-core.el
@@ -205,11 +205,11 @@ at that time."
                                  (if (atom val) val (alist-get 'id val))))
              rows))))
 
-(cl-defgeneric forge--format-url (object slot &optional spec))
+(cl-defgeneric forge--format (object slot &optional spec))
 
-(cl-defmethod forge--format-url ((remote string) slot &optional spec)
+(cl-defmethod forge--format ((remote string) slot &optional spec)
   (if-let ((parts (forge--split-remote-url remote)))
-      (forge--format-url
+      (forge--format
        (forge-get-repository 'stub remote) slot
        (pcase-let* ((`(,host ,owner ,name) parts)
                     (path (if owner (concat owner "/" name) name)))

--- a/lisp/forge-issue.el
+++ b/lisp/forge-issue.el
@@ -119,7 +119,7 @@
          (forge-get-issue repo number))))
 
 (cl-defmethod forge-get-url ((issue forge-issue))
-  (forge--format-url issue 'issue-url-format))
+  (forge--format issue 'issue-url-format))
 
 ;;; Sections
 

--- a/lisp/forge-post.el
+++ b/lisp/forge-post.el
@@ -109,7 +109,7 @@
 (defvar-local forge--cancel-post-function nil)
 (defvar-local forge--pre-post-buffer nil)
 
-(defun forge--prepare-post-buffer (filename)
+(defun forge--prepare-post-buffer (filename &optional header)
   (let ((file (magit-git-dir
                (convert-standard-filename
                 (concat "magit/posts/" filename)))))
@@ -119,6 +119,8 @@
           (buf (find-file-noselect file)))
       (with-current-buffer buf
         (forge-post-mode)
+        (when header
+          (magit-set-header-line-format header))
         (setq forge--pre-post-buffer prevbuf)
         (when resume
           (forge--display-post-buffer buf)

--- a/lisp/forge-post.el
+++ b/lisp/forge-post.el
@@ -51,11 +51,11 @@
 ;;; Utilities
 
 (cl-defmethod forge-get-url ((post forge-post))
-  (forge--format-url post (let ((topic (forge-get-parent post)))
-                            (cond ((forge--childp topic 'forge-issue)
-                                   'issue-post-url-format)
-                                  ((forge--childp topic 'forge-pullreq)
-                                   'pullreq-post-url-format)))))
+  (forge--format post (let ((topic (forge-get-parent post)))
+                        (cond ((forge--childp topic 'forge-issue)
+                               'issue-post-url-format)
+                              ((forge--childp topic 'forge-pullreq)
+                               'pullreq-post-url-format)))))
 
 (cl-defmethod forge-browse :after ((post forge-post))
   (oset (forge-get-topic post) unread-p nil))
@@ -88,9 +88,9 @@
 
 ;;; Utilities
 
-(cl-defmethod forge--format-url ((post forge-post) slot &optional spec)
-  (forge--format-url (forge-get-topic post) slot
-                     `(,@spec (?I . ,(oref post number)))))
+(cl-defmethod forge--format ((post forge-post) slot &optional spec)
+  (forge--format (forge-get-topic post) slot
+                 `(,@spec (?I . ,(oref post number)))))
 
 ;;; Mode
 

--- a/lisp/forge-pullreq.el
+++ b/lisp/forge-pullreq.el
@@ -184,7 +184,7 @@
         (forge--pullreq-ref-1 (oref pullreq number)))))
 
 (cl-defmethod forge-get-url ((pullreq forge-pullreq))
-  (forge--format-url pullreq 'pullreq-url-format))
+  (forge--format pullreq 'pullreq-url-format))
 
 ;;; Sections
 

--- a/lisp/forge-repo.el
+++ b/lisp/forge-repo.el
@@ -235,7 +235,9 @@ forges and hosts.  "
 
 (cl-defmethod forge--format-url ((repo forge-repository) slot &optional spec)
   (format-spec
-   (eieio-oref repo slot)
+   (if (symbolp slot)
+       (eieio-oref repo slot)
+     slot)
    (with-slots (githost owner name) repo
      (let ((path (if owner (concat owner "/" name) name)))
        `(,@spec

--- a/lisp/forge-repo.el
+++ b/lisp/forge-repo.el
@@ -233,11 +233,11 @@ forges and hosts.  "
                       :limit 1]
                      table (oref repo id)))))
 
-(cl-defmethod forge--format-url ((repo forge-repository) slot &optional spec)
+(cl-defmethod forge--format ((repo forge-repository) format-or-slot &optional spec)
   (format-spec
-   (if (symbolp slot)
-       (eieio-oref repo slot)
-     slot)
+   (if (symbolp format-or-slot)
+       (eieio-oref repo format-or-slot)
+     format-or-slot)
    (with-slots (githost owner name) repo
      (let ((path (if owner (concat owner "/" name) name)))
        `(,@spec
@@ -248,7 +248,7 @@ forges and hosts.  "
          (?P . ,(replace-regexp-in-string "/" "%2F" path)))))))
 
 (cl-defmethod forge-get-url ((repo forge-repository))
-  (forge--format-url (oref repo remote) 'remote-url-format))
+  (forge--format (oref repo remote) 'remote-url-format))
 
 (defun forge--set-field-callback ()
   (let ((buf (current-buffer)))

--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -209,9 +209,9 @@ The following %-sequences are supported:
 
 ;;; Utilities
 
-(cl-defmethod forge--format-url ((topic forge-topic) slot &optional spec)
-  (forge--format-url (forge-get-repository topic) slot
-                     `(,@spec (?i . ,(oref topic number)))))
+(cl-defmethod forge--format ((topic forge-topic) slot &optional spec)
+  (forge--format (forge-get-repository topic) slot
+                 `(,@spec (?i . ,(oref topic number)))))
 
 (cl-defmethod forge-visit ((topic forge-topic))
   (let ((magit-generate-buffer-name-function 'forge-topic-buffer-name))
@@ -646,12 +646,12 @@ alist, containing just `text' and `position'.")
         (setq-local bug-reference-url-format
                     (if (forge--childp repo 'forge-gitlab-repository)
                         (lambda ()
-                          (forge--format-url repo
-                                             (if (equal (match-string 3) "#")
-                                                 'issue-url-format
-                                               'pullreq-url-format)
-                                             `((?i . ,(match-string 2)))))
-                      (forge--format-url repo 'issue-url-format '((?i . "%s")))))
+                          (forge--format repo
+                                         (if (equal (match-string 3) "#")
+                                             'issue-url-format
+                                           'pullreq-url-format)
+                                         `((?i . ,(match-string 2)))))
+                      (forge--format repo 'issue-url-format '((?i . "%s")))))
         (setq-local bug-reference-bug-regexp
                     (if (forge--childp repo 'forge-gitlab-repository)
                         "\\(?3:[!#]\\)\\(?2:[0-9]+\\)"


### PR DESCRIPTION
Often times I get confused as to which repository I'm working in.  This patch uses the header-line (as Magithub does) to contextualize the buffer.