### PR TITLE
Generalize topic list insertion

### DIFF
--- a/lisp/forge-issue.el
+++ b/lisp/forge-issue.el
@@ -144,38 +144,11 @@
     map))
 
 (defun forge-insert-issues ()
-  (when-let ((repo (forge-get-repository nil))
-             (- (or (not (slot-boundp repo 'issues-p)) ; temporary KLUDGE
-                    (oref repo issues-p)))
-             (- (not (oref repo sparse-p)))
-             (issues (forge-list-recent-topics repo 'issue)))
-    (magit-insert-section (issues nil t)
-      (magit-insert-heading
-        (format "%s (%s)"
-                (propertize "Issues" 'face 'magit-section-heading)
-                (length issues)))
-      (magit-insert-section-body
-        (let ((width (length (number-to-string (oref (car issues) number)))))
-          (dolist (issue issues)
-            (forge-insert-issue issue width)))
-        (insert ?\n)))))
-
-(defun forge-insert-issue (issue &optional width)
-  (with-slots (number title unread-p closed) issue
-    (magit-insert-section (issue issue)
-      (insert
-       (format (if width
-                   (format "%%-%is %%s%%s\n" (1+ width))
-                 "%s %s%s\n")
-               (propertize (format "#%s" number) 'face 'magit-dimmed)
-               (magit-log-propertize-keywords
-                nil (propertize title 'face
-                                (cond (unread-p 'forge-topic-unread)
-                                      (closed   'forge-topic-closed)
-                                      (t        'forge-topic-open))))
-               (if-let ((labels (forge--format-topic-labels issue)))
-                   (concat " " labels)
-                 ""))))))
+  (when-let ((repo (forge-get-repository nil)))
+    (when (and (not (oref repo sparse-p))
+               (or (not (slot-boundp repo 'issues-p)) ; temporary KLUDGE
+                   (oref repo issues-p)))
+      (forge-insert-topics "Issues" (forge-list-recent-topics repo 'issue)))))
 
 ;;; _
 (provide 'forge-issue)

--- a/lisp/forge-notify.el
+++ b/lisp/forge-notify.el
@@ -96,9 +96,9 @@
               (with-slots (type topic title url unread-p) notify
                 (pcase type
                   ('issue
-                   (forge-insert-issue (forge-get-issue repo topic)))
+                   (forge-insert-topic (forge-get-issue repo topic)))
                   ('pullreq
-                   (forge-insert-pullreq (forge-get-pullreq repo topic)))
+                   (forge-insert-topic (forge-get-pullreq repo topic)))
                   ('commit
                    (magit-insert-section (ncommit nil) ; !commit
                      (string-match "[^/]*\\'" url)

--- a/lisp/forge-pullreq.el
+++ b/lisp/forge-pullreq.el
@@ -254,6 +254,11 @@
         (magit-insert-log (format "%s..%s" (oref pullreq base-ref) ref)
                           magit-log-section-arguments)))))
 
+(cl-defmethod forge--topic-type-prefix ((pullreq forge-pullreq))
+  (if (forge--childp (forge-get-repository pullreq) 'forge-gitlab-repository)
+      "!"
+    "#"))
+
 ;;; _
 (provide 'forge-pullreq)
 ;;; forge-pullreq.el ends here

--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -357,9 +357,9 @@ The following %-sequences are supported:
       (fill-region (point-min) (point-max)))
     (buffer-string)))
 
-(defun forge--topic-type-prefix (topic)
-  (and (forge--childp (forge-get-repository topic) 'forge-gitlab-repository)
-       (if (forge--childp topic 'forge-pullreq) "!" "#")))
+(cl-defmethod forge--topic-type-prefix ((_ forge-topic))
+  "Get the identifier prefix specific to the type of TOPIC."
+  "#")
 
 (defun forge--topic-buffer-lock-value (args)
   (and (derived-mode-p 'forge-topic-mode)


### PR DESCRIPTION
Address issues raised in #79 and #88.

Find below patches that generalize topic and topic-list insertion.  The stars of the show are `forge-insert-topics`, `forge-insert-topic`, and `forge--insert-topic-contents`.

`forge-insert-topics` inserts the section containing the individual topic-sections.  This is the function to use if you want a list of topics.  (I call this the list-section.)

`forge-insert-topic` inserts the section for an individual topic.  (I call this the topic-section.)  This wouldn't be necessary save for topic insertion in notification lists; perhaps there is a better way, but I couldn't find one.

`forge--insert-topic-contents` is the meat of the section -- both the title line and the section contents in the case of pullreqs.  This method uses `forge--format-topic-id` to handle forge-specific semantics (i.e., Gitlab using `!` to reference pull requests) and centralizes the faces used for unread/closed/open topics as well as label insertion after the title.  To effect the listing of commits for pullreqs, an `:after` implementation just for pullreqs is used to insert the heading 'marker' (I call it this, but I don't actually know the implementation) and the actual commit log as before.

---

I hope the above patches prove worthwhile in their own right by reducing duplication, but I think they'll also be very convenient for implementing either `defcustom`-based configuration of any single list-section or defining separate functions for multiple different views of issues/pullreqs within the same status buffer.

The following code is proof-of-concept only; it clearly doesn't function right now.

### Using `defcustom`

``` emacs-lisp
(defun forge-insert-pullreqs ()
  (when-let ((repo (forge-get-repository nil))
             (- (not (oref repo sparse-p))))
    (let ((pullreqs (pcase forge-pullreq-list-configuration
                      (`(by-author . ,author)
                       ;; etc.
                       )
                      (`(by-assignee . ,assignee)
                       ;; etc.
                       )
                      (_
                       ;; using separate configuration in `forge-topic-list-limit'.
                       ;; perhaps it would be good to assume it here.
                       (forge-list-recent-topics repo 'pullreq)))))
      (forge-insert-topics "Pull requests" pullreqs))))
```

### Using separate functions
At its simplest, you can simply copy/paste `forge-insert-pullreqs` using a different source list for the pull requests.  You could get arbitrarily fancy with it, though.

``` emacs-lisp
(defun forge-insert-pullreqs--create (title &optional config)
  (let ((pullreqs-source (pcase config
                           (`(by-author . ,author)
                            ;; etc.
                            )
                           (`(by-assignee . ,assignee)
                            ;; etc.
                            )
                           (_
                            ;; using separate configuration in `forge-topic-list-limit'.
                            ;; perhaps it would be good to assume it here.
                            (lambda () (forge-list-recent-topics repo 'pullreq))))))
    (lambda ()
      (when-let ((repo (forge-get-repository nil))
                 (- (not (oref repo sparse-p))))
        (forge-insert-topics title (funcall pullreqs-source))))))

;; or using a `defmacro' or whatever you'd fancy
(defalias forge-insert-pullreqs-assigned-to-me
  (forge-insert-pullreqs--create
   "PRs assigned to me"
   ;; using hypothetical `forge-current-user'
   `(by-assignee . ,(forge-current-user))))

(defalias forge-insert-pullreqs-created-by-me
  (forge-insert-pullreqs--create
   "My PRs"
   ;; using hypothetical `forge-current-user'
   `(by-author . ,(forge-current-user))))

(defalias forge-insert-pullreqs
  ;; default behavior
  (forge-insert-pullreqs--create "Pull requests"))
```