### PR TITLE
Use EMake for the build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /docs/*.pdf
 /docs/dir
 /docs/forge/
+/.emake/
 /lisp/forge-autoloads.el

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ help:
 	$(info make publish      - publish snapshot manuals)
 	$(info make release      - publish release manuals)
 	$(info make clean        - remove most generated files)
+	$(info make run          - run Emacs with minimal configuration)
+	$(info make dev-run      - like 'make run', but use local packages when available)
+	$(info make deps         - install dependencies)
 	@printf "\n"
 
 lisp:
@@ -50,3 +53,11 @@ clean:
 	@printf "Cleaning...\n"
 	@$(MAKE) -C lisp clean
 	@$(MAKE) -C docs clean
+	@$(MAKE) -f emake.mk clean
+
+dev-run:
+	@$(MAKE) -f emake.mk dev-run
+run:
+	@$(MAKE) -f emake.mk run
+deps:
+	@$(MAKE) -f emake.mk $(EMAKE_WORKDIR)/elpa

--- a/default.mk
+++ b/default.mk
@@ -19,24 +19,29 @@ ELS  += $(PKG)-semi.el
 ELS  += $(PKG)-commands.el
 ELS  += $(PKG)-list.el
 ELCS  = $(ELS:.el=.elc)
-
-DEPS  = closql
-DEPS += dash
-DEPS += hydra # for lv.el
-DEPS += emacsql
-DEPS += ghub
-DEPS += graphql
-DEPS += magit/lisp
-DEPS += markdown-mode
-DEPS += transient/lisp
-DEPS += treepy
-DEPS += with-editor
+PACKAGE_LISP = $(addprefix lisp/,$(ELS))
 
 EMACS      ?= emacs
 EMACS_ARGS ?=
 
-LOAD_PATH  ?= $(addprefix -L ../../,$(DEPS))
-LOAD_PATH  += -L .
+CURL       ?= curl -fsSkL --retry 9 --retry-delay 9
+
+EMAKE_SHA1 ?= e2db14acc21fdf9e0c76377c5165149562c1ed88
+
+EMAKE_WORKDIR  ?= .emake
+EMAKE_LOGLEVEL ?= INFO
+
+EMAKE_ENV += PACKAGE_FILE="$(PKG)-pkg.el"
+EMAKE_ENV += PACKAGE_LISP="$(PACKAGE_LISP)"
+EMAKE_ENV += PACKAGE_ARCHIVES="melpa"
+EMAKE_ENV += EMAKE_WORKDIR="$(EMAKE_WORKDIR)"
+EMAKE_ENV += EMAKE_LOGLEVEL="$(EMAKE_LOGLEVEL)"
+
+EMAKE_BASE ?= $(EMAKE_ENV) $(EMACS) -Q $(EMACS_ARGS) \
+	-L '$(abspath lisp)' \
+	-l '$(EMAKE_WORKDIR)/emake.el' \
+	--eval '(setq enable-dir-local-variables nil)'
+EMAKE ?= $(EMAKE_BASE) --eval "(emake (pop argv))"
 
 ifndef ORG_LOAD_PATH
 ORG_LOAD_PATH  = -L ../../dash

--- a/emake.mk
+++ b/emake.mk
@@ -1,0 +1,35 @@
+-include config.mk
+include default.mk
+
+.PHONY: run clean install
+
+$(EMAKE_WORKDIR)/elpa: EMACS_ARGS += --batch
+$(EMAKE_WORKDIR)/elpa: $(EMAKE_WORKDIR)/emake.el
+	$(EMAKE) install
+
+$(EMAKE_WORKDIR)/emake.el:
+	@mkdir -p $(EMAKE_WORKDIR)
+	$(CURL) 'https://raw.githubusercontent.com/vermiculus/emake.el/$(EMAKE_SHA1)/emake.el' \
+	    --output '$(EMAKE_WORKDIR)/emake.el'
+
+clean:
+	@printf "Cleaning...\n"
+	@rm -rf $(EMAKE_WORKDIR)
+
+# Run Emacs with minimal configuration
+dev-run: $(EMAKE_WORKDIR)/emake.el $(EMAKE_WORKDIR)/elpa
+	@$(EMAKE_BASE) -f emake-setup-load-path
+
+# Like `dev-run', but always install from MELPA
+run: EMAKE_ENV += EMAKE_USE_LOCAL="NEVER"
+run: dev-run
+
+install: $(EMAKE_WORKDIR)/elpa
+
+compile: EMACS_ARGS += --batch
+compile: $(EMAKE_WORKDIR)/elpa $(EMAKE_WORKDIR)/emake.el
+	@$(EMAKE) compile
+
+loaddefs: EMACS_ARGS += --batch
+loaddefs: $(PACKAGE_LISP) $(EMAKE_WORKDIR)/emake.el
+	@$(EMAKE) autoloads

--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -1,14 +1,8 @@
 -include ../config.mk
 include ../default.mk
 
-lisp: $(ELCS) loaddefs
-
-loaddefs: $(PKG)-autoloads.el
-
-%.elc: %.el
-	@printf "Compiling $<\n"
-	@$(EMACS) -Q --batch $(EMACS_ARGS) \
-	$(LOAD_PATH) --funcall batch-byte-compile $<
+lisp: loaddefs $(ELS)
+	@cd .. && $(MAKE) -f emake.mk compile
 
 CLEAN  = $(ELCS) $(PKG)-autoloads.el
 
@@ -16,30 +10,6 @@ clean:
 	@printf "Cleaning...\n"
 	@rm -rf $(CLEAN)
 
-define LOADDEFS_TMPL
-;;; $(PKG)-autoloads.el --- automatically extracted autoloads
-;;
-;;; Code:
-(add-to-list 'load-path (directory-file-name \
-(or (file-name-directory #$$) (car load-path))))
-
-;; Local Variables:
-;; version-control: never
-;; no-byte-compile: t
-;; no-update-autoloads: t
-;; End:
-;;; $(PKG)-autoloads.el ends here
-endef
-export LOADDEFS_TMPL
-#'
-
+loaddefs: $(PKG)-autoloads.el
 $(PKG)-autoloads.el: $(ELS)
-	@printf "Generating $@\n"
-	@printf "%s" "$$LOADDEFS_TMPL" > $@
-	@$(EMACS) -Q --batch --eval "(progn\
-	(setq make-backup-files nil)\
-	(setq vc-handled-backends nil)\
-	(setq default-directory (file-truename default-directory))\
-	(setq generated-autoload-file (expand-file-name \"$@\"))\
-	(setq find-file-visit-truename t)\
-	(update-directory-autoloads default-directory))"
+	@cd .. && $(MAKE) -f emake.mk loaddefs


### PR DESCRIPTION
Key advantages:

- There is no longer an expected structure above the root directory of this project.  (I can compile with `make clean lisp` now... #90)

- The dependency list is no longer maintained in two places (`default.mk` and `*-pkg.el`)

Note some setup will have to be done in config.mk for packages that are available from above the root directory of this project; make sure to add the necessary load-path code to `EMACS_ARGS`.