### PR TITLE
WIP Topic subsets

### DIFF
--- a/lisp/forge-db.el
+++ b/lisp/forge-db.el
@@ -64,10 +64,14 @@
 
 ;;; Api
 
-(defun forge-sql (sql &rest args)
+(defun forge--sql (db sql &rest args)
   (if (stringp sql)
-      (emacsql (forge-db) (apply #'format sql args))
-    (apply #'emacsql (forge-db) sql args)))
+      (emacsql db (apply #'format sql args))
+    (apply #'emacsql db sql args)))
+
+(defun forge-sql (sql &rest args)
+  (apply #'forge--sql (forge-db) sql args))
+
 
 ;;; Schemata
 

--- a/lisp/forge-db.el
+++ b/lisp/forge-db.el
@@ -72,6 +72,14 @@
 (defun forge-sql (sql &rest args)
   (apply #'forge--sql (forge-db) sql args))
 
+(defun forge-sql* (table sql-list &rest args)
+  (declare (indent 2))
+  (let ((db (forge-db))
+        (prefix (vector :select '* :from table))
+        results)
+    (dolist (sql sql-list)
+      (setq results (nconc results (apply #'forge--sql db (vconcat prefix sql) args))))
+    (cl-delete-duplicates results :test #'equal)))
 
 ;;; Schemata
 


### PR DESCRIPTION
Fix #79; Fix #88

I plan to implement this over the weekend; the current patches prepare for that.

One open question that I have is what you'd like to do for configuration.

> However instead of providing alternative section inserters I think I favor teaching the existing inserters to display different sets depending on settings that can set using configuration popups (similar to `L` and `D` for log and diff arguments) and to display the settings at the end of the list section heading.

I do plan on creating alternative section inserters in this pull request, but I also want to get more of your thoughts on your idea for a configurable catch-all section (which would remain the default).  Specifically, how do you imagine the configuration taking place?

- git variables (what I did in Magithub; wasn't too bad, but became difficult to manage)
- many `defcustom` variables (this could still grow to an untenable number of options with documentation strewn all about the place)
- one 'complex' `defcustom` variable per topic-type (issue, pullreq) – likely an alist of individual options
- something else?

(I'm looking forward to this opportunity to work with Transient :smile:)