### PR TITLE
Fix docstring

### DIFF
--- a/default.mk
+++ b/default.mk
@@ -22,7 +22,6 @@ ELCS  = $(ELS:.el=.elc)
 
 DEPS  = closql
 DEPS += dash
-DEPS += hydra # for lv.el
 DEPS += emacsql
 DEPS += ghub
 DEPS += graphql

--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -43,7 +43,7 @@ for a repository using the command `forge-add-pullreq-refspec'."
 ;;; Dispatch
 
 ;;;###autoload (autoload 'forge-dispatch "forge-commands" nil t)
-(define-transient-command forge-dispatch
+(define-transient-command forge-dispatch ()
   "Dispatch a forge command."
   [["Fetch"
     ("f f" "topics"        forge-pull)


### PR DESCRIPTION
`forge-dispatch` is missing the arglist argument. This adds it, which lets forge-dispatch have documentation.