### PR TITLE
Autoload forge-dispatch

### DIFF
--- a/lisp/forge.el
+++ b/lisp/forge.el
@@ -64,7 +64,9 @@
 
 ;;; Add Bindings
 
-(define-key magit-mode-map "'" 'forge-dispatch)
+;;;###autoload
+(with-eval-after-load 'magit-mode
+  (define-key magit-mode-map "'" 'forge-dispatch))
 
 (define-key magit-commit-section-map [remap magit-browse-thing] 'forge-browse-dwim)
 (define-key magit-remote-section-map [remap magit-browse-thing] 'forge-browse-remote)


### PR DESCRIPTION
This adds an autoload so that ' is bound to forge-dispatch in magit buffers without users explicitly needing to require forge.