### PR TITLE
Disable Markdown inline images in terminal

### DIFF
--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -339,7 +339,8 @@ identifier."
                                     'magit-diff-hunk-heading t heading)
             (magit-insert-heading heading))
           (insert (forge--fontify-markdown body) "\n\n"))))
-    (when (fboundp 'markdown-display-inline-images)
+    (when (and (display-images-p)
+               (fboundp 'markdown-display-inline-images))
       (let ((markdown-display-remote-images t))
         (markdown-display-inline-images)))))
 


### PR DESCRIPTION
Condition display of inline images on `(display-images-p)`

`(markdown-display-inline-images)` errors when the display cannot display images (e.g., terminal).  This causes `magit-refresh-buffer` to terminate early and subsequent navigation in a Topic buffer errors with `Error in post-command-hook (magit-section-update-highlight): (wrong-type-argument number-or-marker-p nil)`.