### PR TITLE
forges: add a new common gitlab instance "framagit"

### DIFF
--- a/docs/forge.org
+++ b/docs/forge.org
@@ -108,6 +108,7 @@ also see [[*Getting Started]].
 
   - https://gitlab.com
   - https://salsa.debian.org
+  - https://framagit.org
 
 ** Partially Supported Forges
 :PROPERTIES:

--- a/docs/forge.texi
+++ b/docs/forge.texi
@@ -190,6 +190,9 @@ Gitlab Hosts
 
 @item
 @uref{https://salsa.debian.org}
+
+@item
+@uref{https://framagit.org}
 @end itemize
 @end itemize
 

--- a/lisp/forge-core.el
+++ b/lisp/forge-core.el
@@ -56,6 +56,8 @@
      "gitlab.com" forge-gitlab-repository)
     ("salsa.debian.org" "salsa.debian.org/api/v4"
      "salsa.debian.org" forge-gitlab-repository)
+    ("framagit.org" "framagit.org/api/v4"
+     "framagit.org" forge-gitlab-repository)
     ;; Forges (API unsupported)
     ("codeberg.org" "codeberg.org/api/v1"
      "codeberg.org" forge-gitea-repository)


### PR DESCRIPTION
Framasoft is a well known non profit organisation (at least in France)
which offers a set of free (speech) software tools hosted for the well
being of public users. Details on https://framasoft.org/en/.

[Framagit](https://framagit.org/) is one of the service they offer to the public which is a
common Gitlab instance. (Similar to Debian's Salsa instance).

The intention of this PR is to add the framagit.org instance as a
forge.

I guess the way to add "gitlab.com-like forges" might need a special
feature inside Forge's codebase. There is a workaround to configure
local emacs configuration to use private instances seen in #9. But
maybe "well-known" and "important" public instances could still be
listed inside Forge's code.

WDYT? Thanks!