### PR TITLE
fix(labels): label containing UTF-8 characters made forge-pull crash

### DIFF
--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -130,22 +130,26 @@ This variable has to be customized before `forge' is loaded."
 (cl-defmethod forge--object-id ((class (subclass forge-topic)) repo number)
   "Return the id for a CLASS object in REPO identified by id NUMBER."
   (base64-encode-string
-   (format "%s:%s%s"
-           (base64-decode-string (oref repo id))
-           (substring (symbol-name class)
-                      (length (oref-default class closql-class-prefix)))
-           number)
+   (encode-coding-string
+    (format "%s:%s%s"
+            (base64-decode-string (oref repo id))
+            (substring (symbol-name class)
+                       (length (oref-default class closql-class-prefix)))
+            number)
+    'utf-8)
    t))
 
 (cl-defmethod forge--object-id ((prefix string) id)
   (base64-encode-string
-   (format "%s:%s"
-           (base64-decode-string prefix)
-           ;; TODO Simply use `id', which is always an integer, except
-           ;; when called by `forge--update-labels(gitlab)', in which
-           ;; case the string also shouldn't be decoded because it is
-           ;; NOT base64 encoded.
-           (or (ignore-errors (base64-decode-string id)) id))
+   (encode-coding-string
+    (format "%s:%s"
+            (base64-decode-string prefix)
+            ;; TODO Simply use `id', which is always an integer, except
+            ;; when called by `forge--update-labels(gitlab)', in which
+            ;; case the string also shouldn't be decoded because it is
+            ;; NOT base64 encoded.
+            (or (ignore-errors (base64-decode-string id)) id))
+    'utf-8)
    t))
 
 ;;; Query

--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -139,16 +139,19 @@ This variable has to be customized before `forge' is loaded."
     'utf-8)
    t))
 
-(cl-defmethod forge--object-id ((prefix string) id)
+(cl-defmethod forge--object-id ((prefix string) number-or-id)
   (base64-encode-string
    (encode-coding-string
     (format "%s:%s"
             (base64-decode-string prefix)
-            ;; TODO Simply use `id', which is always an integer, except
-            ;; when called by `forge--update-labels(gitlab)', in which
-            ;; case the string also shouldn't be decoded because it is
-            ;; NOT base64 encoded.
-            (or (ignore-errors (base64-decode-string id)) id))
+            (if (numberp number-or-id)
+                number-or-id
+              ;; Currently every id is base64 encode.  Unfortunately
+              ;; we cannot use the ids of Gitlab labels (see comment
+              ;; in the respective `forge--update-labels' method),
+              ;; and have to use their names, which are not encoded.
+              (or (ignore-errors (base64-decode-string number-or-id))
+                  number-or-id)))
     'utf-8)
    t))
 


### PR DESCRIPTION
The crash stacktrace looks like:

```
Debugger entered--Lisp error: (error "Multibyte character in data for base64 encoding")
  base64-encode-string("framagit.org:16:💪 Contribution Week" t)
  [...]
  forge--object-id("ZnJhbWFnaXQub3JnOjE2" "💪 Contribution Week")
  [...]
  forge--update-labels(#<forge-gitlab-repository forge-gitlab-repository> (((id . 38546) (name . "💪 Contribution Week") (color . "#69D100") (description . "Issues select...
```

I used the recommendation from this Emacs mailing list
https://lists.gnu.org/archive/html/help-gnu-emacs/2012-04/msg00173.html
to force the encoding with the `encode-coding-string` function before
calling the base64-encode function.

Testing on a fake personnal project
https://gitlab.com/paulrbr/test-markdown/issues/1 seems to work.