### PR TITLE
Fix 'missing' function forge-list-browse-pullreq

### DIFF
--- a/lisp/forge-list.el
+++ b/lisp/forge-list.el
@@ -119,8 +119,8 @@
   (interactive)
   (forge-visit-pullreq (forge-get-pullreq (tabulated-list-get-id))))
 
-(defun forge-list-browse-issue ()
-  "Visit the url corresponding to the issue at point in a browser."
+(defun forge-list-browse-pullreq ()
+  "Visit the url corresponding to the pull-request at point in a browser."
   (interactive)
   (forge-browse-pullreq (forge-get-pullreq (tabulated-list-get-id))))
 


### PR DESCRIPTION
This is fix for #136. The name `forge-list-browse-issue` is used for both
commands resulting in the function `forge-list-browse-pullreq` to be
missing. Sorry for the oversight.