### PR TITLE
Display base and head branch refs for pull requests

### DIFF
--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -312,6 +312,7 @@ identifier."
 (defvar forge-topic-headers-hook
   '(forge-insert-topic-title
     forge-insert-topic-state
+    forge-insert-topic-refs
     forge-insert-topic-labels
     forge-insert-topic-marks
     forge-insert-topic-assignees
@@ -494,6 +495,33 @@ Return a value between 0 and 1."
   "Calculate the luminance of color composed of RED, GREEN and BLUE.
 Return a value between 0 and 1."
   (/ (+ (* .2126 red) (* .7152 green) (* .0722 blue)) 256))
+
+(cl-defun forge-insert-topic-refs
+    (&optional (topic forge-buffer-topic))
+  (when (forge-pullreq-p topic)
+    (magit-insert-section (topic-refs)
+      (let* ((repo-separator (propertize ":" 'face 'magit-dimmed))
+             (refs-separator (propertize "..." 'face 'magit-dimmed))
+             (deleted (propertize "(deleted)" 'face 'magit-dimmed))
+             (cross-repo-p (oref topic cross-repo-p))
+             (base-repo (oref topic base-repo))
+             (base-ref (oref topic base-ref))
+             (head-repo (oref topic head-repo))
+             (head-ref (oref topic head-ref))
+             (full-base-ref (if cross-repo-p
+                                (concat base-repo repo-separator base-ref)
+                              base-ref))
+             ;; Need to check if head repo or ref are deleted.
+             (full-head-ref (if cross-repo-p
+                                (if (and head-repo head-ref)
+                                    (concat head-repo repo-separator head-ref)
+                                  deleted)
+                              (or head-ref deleted))))
+        (insert (format "%-11s" "Refs: ")
+                full-base-ref
+                refs-separator
+                full-head-ref
+                "\n")))))
 
 (defvar forge-topic-assignees-section-map
   (let ((map (make-sparse-keymap)))

--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -500,28 +500,20 @@ Return a value between 0 and 1."
     (&optional (topic forge-buffer-topic))
   (when (forge-pullreq-p topic)
     (magit-insert-section (topic-refs)
-      (let* ((repo-separator (propertize ":" 'face 'magit-dimmed))
-             (refs-separator (propertize "..." 'face 'magit-dimmed))
-             (deleted (propertize "(deleted)" 'face 'magit-dimmed))
-             (cross-repo-p (oref topic cross-repo-p))
-             (base-repo (oref topic base-repo))
-             (base-ref (oref topic base-ref))
-             (head-repo (oref topic head-repo))
-             (head-ref (oref topic head-ref))
-             (full-base-ref (if cross-repo-p
-                                (concat base-repo repo-separator base-ref)
-                              base-ref))
-             ;; Need to check if head repo or ref are deleted.
-             (full-head-ref (if cross-repo-p
-                                (if (and head-repo head-ref)
-                                    (concat head-repo repo-separator head-ref)
-                                  deleted)
-                              (or head-ref deleted))))
-        (insert (format "%-11s" "Refs: ")
-                full-base-ref
-                refs-separator
-                full-head-ref
-                "\n")))))
+      (with-slots (cross-repo-p base-repo base-ref head-repo head-ref) topic
+        (let ((separator (propertize ":" 'face 'magit-dimmed))
+              (deleted (propertize "(deleted)" 'face 'magit-dimmed)))
+          (insert (format "%-11s" "Refs: ")
+                  (if cross-repo-p
+                      (concat base-repo separator base-ref)
+                    base-ref)
+                  (propertize "..." 'face 'magit-dimmed)
+                  (if cross-repo-p
+                      (if (and head-repo head-ref)
+                          (concat head-repo separator head-ref)
+                        deleted)
+                    (or head-ref deleted))
+                  "\n"))))))
 
 (defvar forge-topic-assignees-section-map
   (let ((map (make-sparse-keymap)))


### PR DESCRIPTION
This is an attempt to show branch refs for PRs.
I find this information useful as I often need to confirm which branch the PR is made from and to.

`Refs` is probably not the best name for this, but that's what it's defined as by GH API.
More than happy to change this. 

_Sample output:_

```
Refs:      sigma/gh.el:master...yuya373/gh.el:set-async-from-api
```

![image](https://user-images.githubusercontent.com/1171466/61182566-64992800-a689-11e9-846a-d32033afefde.png)

