### PR TITLE
forge--pull: Indicate when topic pull is not supported

### DIFF
--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -117,7 +117,8 @@ If pulling is too slow, then also consider setting the Git variable
       (message "Please enter a date in the format YYYY-MM-DD.")
       (sit-for 1))))
 
-(cl-defmethod forge--pull ((_repo forge-noapi-repository) _until)) ; NOOP
+(cl-defmethod forge--pull ((repo forge-noapi-repository) _until) ; NOOP
+  (forge--msg repo t t "Pulling from REPO is not supported"))
 
 (cl-defmethod forge--pull ((repo forge-unusedapi-repository) _until)
   (oset repo sparse-p nil)


### PR DESCRIPTION
I'm trying to set up forge for my bitbucket (yes, I know they do not have full support) repos, and was confused by the "Pulling REPO...." message that wouldn't go away. Was I doing something wrong?
When we know something is not supported, just say so.