### PR TITLE
Fix forge-delete-post

### DIFF
--- a/docs/forge.org
+++ b/docs/forge.org
@@ -728,9 +728,9 @@ a post visits that post in a browser.
   This command reads a list of people who you would like to review an
   existing topic in the minibuffer.
 
-- Key: C-c C-k [on a comment section], forge-delete-comment
+- Key: C-c C-k [on a post section], forge-delete-post
 
-  This command deletes the comment at point.
+  This command deletes the post at point.
 
 Creating a new post and editing an existing post are similar to
 creating a new commit and editing the message of an existing commit.

--- a/docs/forge.texi
+++ b/docs/forge.texi
@@ -1008,11 +1008,11 @@ minibuffer.
 This command reads a list of people who you would like to review an
 existing topic in the minibuffer.
 
-@kindex C-c C-k [on a comment section]
-@cindex forge-delete-comment
-@item @kbd{C-c C-k [on a comment section]} @tie{}@tie{}@tie{}@tie{}(@code{forge-delete-comment})
+@kindex C-c C-k [on a post section]
+@cindex forge-delete-post
+@item @kbd{C-c C-k [on a post section]} @tie{}@tie{}@tie{}@tie{}(@code{forge-delete-post})
 
-This command deletes the comment at point.
+This command deletes the post at point.
 @end table
 
 Creating a new post and editing an existing post are similar to

--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -525,12 +525,14 @@ topic N and modify that instead."
 
 ;;; Delete
 
-(defun forge-delete-comment (comment)
-  "Delete the comment at point."
-  (interactive (list (or (forge-comment-at-point)
+(defun forge-delete-post (post)
+  "Delete the POST at point."
+  (interactive (list (or (forge-post-at-point)
                          (user-error "There is no post at point"))))
   (when (yes-or-no-p "Do you really want to delete the selected comment? ")
-    (forge--delete-comment (forge-get-repository t) comment)))
+    (forge--delete-post (forge-get-repository t) post)
+    (closql-delete post)
+    (magit-refresh)))
 
 ;;; Branch
 

--- a/lisp/forge-github.el
+++ b/lisp/forge-github.el
@@ -500,11 +500,9 @@ repositories.
                    :payload labels
                    :callback (forge--set-field-callback)))
 
-(cl-defmethod forge--delete-comment
+(cl-defmethod forge--delete-post
   ((_repo forge-github-repository) post)
-  (forge--ghub-delete post "/repos/:owner/:repo/issues/comments/:number")
-  (closql-delete post)
-  (magit-refresh))
+  (forge--ghub-delete post "/repos/:owner/:repo/issues/comments/:number"))
 
 (cl-defmethod forge--set-topic-assignees
   ((_repo forge-github-repository) topic assignees)

--- a/lisp/forge-gitlab.el
+++ b/lisp/forge-gitlab.el
@@ -458,13 +458,11 @@ it is all or nothing.")
 
 (cl-defmethod forge--submit-edit-post ((_ forge-gitlab-repository) post)
   (forge--glab-put post
-    (cl-typecase post
+    (cl-etypecase post
       (forge-pullreq "/projects/:project/merge_requests/:number")
       (forge-issue   "/projects/:project/issues/:number")
-      (forge-post
-       (if (forge-issue-p (forge-get-topic post))
-           "/projects/:project/issues/:topic/notes/:number"
-         "/projects/:project/merge_requests/:topic/notes/:number")))
+      (forge-issue-post "/projects/:project/issues/:topic/notes/:number")
+      (forge-pullreq-post "/projects/:project/merge_requests/:topic/notes/:number"))
     (if (cl-typep post 'forge-topic)
         (let-alist (forge--topic-parse-buffer)
           ;; Keep Gitlab from claiming that the user

--- a/lisp/forge-gitlab.el
+++ b/lisp/forge-gitlab.el
@@ -513,7 +513,7 @@ it is all or nothing.")
        (forge--set-topic-field repo topic 'assignee_ids
                                (--map (caddr (assoc it users)) assignees))))))
 
-(cl-defmethod forge--delete-comment
+(cl-defmethod forge--delete-post
   ((_repo forge-gitlab-repository) post)
   (forge--glab-delete
    post
@@ -521,9 +521,7 @@ it is all or nothing.")
      (forge-pullreq-post
       "/projects/:project/merge_requests/:topic/notes/:number")
      (forge-issue-post
-      "/projects/:project/issues/:topic/notes/:number")))
-  (closql-delete post)
-  (magit-refresh))
+      "/projects/:project/issues/:topic/notes/:number"))))
 
 (cl-defmethod forge--topic-templates ((repo forge-gitlab-repository)
                                       (_ (subclass forge-issue)))

--- a/lisp/forge-post.el
+++ b/lisp/forge-post.el
@@ -65,12 +65,6 @@
 (defun forge-post-at-point ()
   (magit-section-value-if '(issue pullreq post)))
 
-(defun forge-comment-at-point ()
-  (and (magit-section-value-if '(post))
-       (let ((post (oref (magit-current-section) value)))
-         (or (forge-pullreq-post-p post)
-             (forge-issue-post-p post)))))
-
 (defun forge-topic-at-point ()
   (or (magit-section-value-if '(issue pullreq))
       (when-let ((branch (magit-branch-at-point)))

--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -360,7 +360,7 @@ identifier."
   (let ((map (make-sparse-keymap)))
     (define-key map [remap magit-browse-thing] 'forge-browse-post)
     (define-key map [remap magit-edit-thing]   'forge-edit-post)
-    (define-key map (kbd "C-c C-k")            'forge-delete-comment)
+    (define-key map (kbd "C-c C-k")            'forge-delete-post)
     map))
 
 (defvar-local forge-buffer-topic nil)


### PR DESCRIPTION
`forge-delete-post' used to be `forge-delete-comment', and it was
broken.

* Rename `forge-delete-comment' -> `forge-delete-post'
* Rename `forge--delete-comment' -> `forge--delete-post'
* Move common code from `forge--delete-post' to `forge-delete-post'
* Remove `forge-comment-at-point', no longer used

Closes #195.

#