### PR TITLE
WIP: bitbucket issues support

### DIFF
--- a/lisp/forge-bitbucket.el
+++ b/lisp/forge-bitbucket.el
@@ -278,6 +278,23 @@ Callback function CB should accept itself as argument."
                     :callback  (forge--post-submit-callback)
                     :errorback (forge--post-submit-errorback)))
 
+(cl-defmethod forge--set-topic-field
+  ((_repo forge-bitbucket-repository) topic field value)
+  "Set a TOPIC FIELD to VALUE."
+  ;; checkdoc-params: (forge-bitbucket-repository)
+  (forge--buck-put topic
+    (cl-typecase topic
+      (forge-pullreq "/repositories/:project/pullrequests/:number") ; TODO: Not sure this works
+      (forge-issue   "/repositories/:project/issues/:number"))
+    `((,field . ,value))
+    :callback (forge--set-field-callback)))
+
+(cl-defmethod forge--set-topic-title
+  ((repo forge-bitbucket-repository) topic title)
+  "Set the bitbucket REPO TOPIC TITLE."
+  ;; checkdoc-params: (forge-bitbucket-repository)
+  (forge--set-topic-field repo topic 'title title))
+
 (cl-defmethod forge--topic-templates ((_repo forge-bitbucket-repository)
                                       (_topic (subclass forge-issue)))
   "Bitbucket does not support issue templates."

--- a/lisp/forge-bitbucket.el
+++ b/lisp/forge-bitbucket.el
@@ -304,6 +304,12 @@ Callback function CB should accept itself as argument."
                             (closed "open")
                             (open   "closed"))))
 
+(cl-defmethod forge--set-topic-labels
+  ((_repo forge-bitbucket-repository) _topic _labels)
+  "Bitbucket does not support labels."
+  ;; checkdoc-params: (forge-bitbucket-repository)
+  (user-error "Bitbucket does not support labels"))
+
 (cl-defmethod forge--topic-templates ((_repo forge-bitbucket-repository)
                                       (_topic (subclass forge-issue)))
   "Bitbucket does not support issue templates."

--- a/lisp/forge-bitbucket.el
+++ b/lisp/forge-bitbucket.el
@@ -39,6 +39,98 @@
    (create-issue-url-format   :initform "https://%h/%o/%n/issues/new")
    (create-pullreq-url-format :initform "https://%h/%o/%n/pull-requests/new")))
 
+;;; Utilities
+
+(cl-defun forge--buck-get (obj resource
+                               &optional params
+                               &key query payload headers
+                               silent unpaginate noerror reader
+                               username host
+                               callback errorback extra)
+  "Perform a GET request to the bibucket API.
+OBJ is any forge struct, used to transform RESOURCE."
+  (declare (indent defun))
+  (buck-get (if obj (forge--format-resource obj resource) resource)
+            params
+            :host (or host (oref (forge-get-repository obj) apihost))
+            :auth 'forge
+            :query query :payload payload :headers headers
+            :silent silent :unpaginate unpaginate
+            :noerror noerror :reader reader
+            :username username
+            :callback callback
+            :errorback (or errorback (and callback t))
+            :extra extra))
+
+(cl-defun forge--buck-put (obj resource
+                               &optional params
+                               &key query payload headers
+                               silent unpaginate noerror reader
+                               host callback errorback)
+  "Perform a PUT request to the bitbucket API.
+OBJ is any forge struct, used to transform RESOURCE.  The API
+call is done using the `buck' API of ghub.el.  PARAMS, QUERY,
+PAYLOAD, HEADERS, SILENT, UNPAGINATE, NOERROR, READER, HOST,
+CALLBACK, and ERRORBACK is passed unmodified to `buck-put'.
+If HOST is nil, use the `apihost' of the OBJ repository.
+RESOURCE is not transformed if OBJ is nil.  If ERRORBACK is nil,
+use CALLBACK for errors too."
+  (declare (indent defun))
+  (buck-put (if obj (forge--format-resource obj resource) resource)
+            params
+            :host (or host (oref (forge-get-repository obj) apihost))
+            :auth 'forge
+            :query query :payload payload :headers headers
+            :silent silent :unpaginate unpaginate
+            :noerror noerror :reader reader
+            :callback callback
+            :errorback (or errorback (and callback t))))
+
+(cl-defun forge--buck-post (obj resource
+                                &optional params
+                                &key query payload headers
+                                silent unpaginate noerror reader
+                                username host
+                                callback errorback extra)
+  "Perform a POST request to the bitbucket API.
+OBJ is any forge struct, used to transform RESOURCE.  The API
+call is done using the `buck' API of ghub.el.  PARAMS,
+QUERY, PAYLOAD, HEADERS, SILENT, UNPAGINATE, NOERROR, READER,
+USERNAME, HOST, CALLBACK, ERRORCALLBACK, and EXTRA is passed
+unmodified to `buck-post'.
+If HOST is nil, use the `apihost' of the OBJ repository.
+RESOURCE is not transformed if OBJ is nil.
+If ERRORBACK is nil, use CALLBACK for errors too."
+  (declare (indent defun))
+  (setq host (or host (oref (forge-get-repository obj) apihost)))
+  (buck-post (if obj (forge--format-resource obj resource) resource)
+             params
+             :host host
+             :auth 'forge
+             :query query :payload payload :headers headers
+             :silent silent :unpaginate unpaginate
+             :noerror noerror :reader reader
+             :username username
+             :callback callback
+             :errorback (or errorback (and callback t))
+             :extra extra))
+
+(cl-defun forge--buck-delete (obj resource
+                                  &optional params
+                                  &key query payload headers
+                                  silent unpaginate noerror reader
+                                  host callback errorback)
+  (declare (indent defun))
+  (buck-delete (if obj (forge--format-resource obj resource) resource)
+               params
+               :host (or host (oref (forge-get-repository obj) apihost))
+               :auth 'forge
+               :query query :payload payload :headers headers
+               :silent silent :unpaginate unpaginate
+               :noerror noerror :reader reader
+               :callback callback
+               :errorback (or errorback (and callback t))))
+
 ;;; _
 (provide 'forge-bitbucket)
 ;;; forge-bitbucket.el ends here

--- a/lisp/forge-bitbucket.el
+++ b/lisp/forge-bitbucket.el
@@ -339,6 +339,15 @@ Callback function CB should accept itself as argument."
          (user (caddr (assoc (car assignees) users))))
     (forge--put-topic-json topic `((assignee . ((username . ,(car assignees))))))))
 
+(cl-defmethod forge--delete-comment ((_repo forge-bitbucket-repository) post)
+  "Delete a Bitbucket topic POST, which must be a comment."
+  ;; checkdoc-params: (forge-bitbucket-repository)
+  (forge--buck-delete
+   post
+   (cl-etypecase post
+     (forge-pullreq-post "/repositories/:project/pullrequests/:topic/comments/:number")
+     (forge-issue-post   "/repositories/:project/issues/:topic/comments/:number"))))
+
 (cl-defmethod forge--topic-templates ((_repo forge-bitbucket-repository)
                                       (_topic (subclass forge-issue)))
   "Bitbucket does not support issue templates."

--- a/lisp/forge-bitbucket.el
+++ b/lisp/forge-bitbucket.el
@@ -253,6 +253,17 @@ Callback function CB should accept itself as argument."
                             .id)))
                   data))))
 
+;;; Mutations
+
+(cl-defmethod forge--submit-create-post ((_repo forge-bitbucket-repository) topic)
+  (forge--buck-post topic
+                    (if (forge-issue-p topic)
+                        "/repositories/:project/issues/:number/comments/"
+                      "/repositories/:project/pullrequests/:number/comments/")
+                    nil
+                    :payload `((content . ((raw . ,(string-trim (buffer-string))))))
+                    :callback  (forge--post-submit-callback)
+                    :errorback (forge--post-submit-errorback)))
 
 ;;; Utilities
 

--- a/lisp/forge-bitbucket.el
+++ b/lisp/forge-bitbucket.el
@@ -295,6 +295,15 @@ Callback function CB should accept itself as argument."
   ;; checkdoc-params: (forge-bitbucket-repository)
   (forge--set-topic-field repo topic 'title title))
 
+(cl-defmethod forge--set-topic-state
+  ((repo forge-bitbucket-repository) topic)
+  "Change the state of bitbucket REPO TOPIC."
+  ;; checkdoc-params: (forge-bitbucket-repository)
+  (forge--set-topic-field repo topic 'state
+                          (cl-ecase (oref topic state) ; TODO: Handle bitbucket states better
+                            (closed "open")
+                            (open   "closed"))))
+
 (cl-defmethod forge--topic-templates ((_repo forge-bitbucket-repository)
                                       (_topic (subclass forge-issue)))
   "Bitbucket does not support issue templates."

--- a/lisp/forge-bitbucket.el
+++ b/lisp/forge-bitbucket.el
@@ -41,6 +41,13 @@
 
 ;;; Utilities
 
+(defun forge--bitbucket-hack-iso8601 (time)
+  "Return TIME - an ISO8601 timestamp - with no more than three second decimals."
+  (and time
+    (if (string-match "T[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\\.[0-9]\\{3\\}\\([0-9]+\\)" time)
+        (replace-match "" nil t time 1)
+      time)))
+
 (cl-defun forge--buck-get (obj resource
                                &optional params
                                &key query payload headers

--- a/lisp/forge-bitbucket.el
+++ b/lisp/forge-bitbucket.el
@@ -278,6 +278,23 @@ Callback function CB should accept itself as argument."
                     :callback  (forge--post-submit-callback)
                     :errorback (forge--post-submit-errorback)))
 
+(cl-defmethod forge--submit-edit-post ((_ forge-bitbucket-repository) post)
+  "Edit a topic or POST."
+  ;; checkdoc-params: (forge-bitbucket-repository)
+  (forge--buck-put post
+    (cl-etypecase post
+      (forge-pullreq "/repositories/:project/pullrequests/:number")
+      (forge-issue   "/repositories/:project/issues/:number")
+      (forge-pullreq-post "/repositories/:project/pullrequests/:topic/comments/:number")
+      (forge-issue-post "/repositories/:project/issues/:topic/comments/:number"))
+    (if (cl-typep post 'forge-topic)
+        (let-alist (forge--topic-parse-buffer)
+          `((title . , .title)
+            (content . ((raw . , .body)))))
+      `((content . ((raw . ,(string-trim (buffer-string)))))))
+    :callback  (forge--post-submit-callback)
+    :errorback (forge--post-submit-errorback)))
+
 (defun forge--put-topic-json (topic json)
   "TOPIC JSON."
   (forge--buck-put topic


### PR DESCRIPTION
This is the current status of my work to add bitbucket support to
forge.

~~I think all issue operations are supported, but it does rely on #196,
which is also included in this PR.~~

It relies on https://github.com/magit/ghub/pull/97 for mutating
operations. 

I would appreciate all feedback on how to improve this code, and tips
on things in the forge architecture that I have missed.