### PR TITLE
Add forge-insert-requested-pullreqs, to see review requests easily

### DIFF
--- a/docs/forge.org
+++ b/docs/forge.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Forge: (forge).
 #+TEXINFO_DIR_DESC: Access Git Forges from Magit
-#+SUBTITLE: for version 0.1.0 (v0.1.0-297-gb8baf139+1)
+#+SUBTITLE: for version 0.1.0 (v0.1.0-299-gfb04716b+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:4 toc:2
@@ -20,7 +20,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 #+TEXINFO: @noindent
-This manual is for Forge version 0.1.0 (v0.1.0-297-gb8baf139+1).
+This manual is for Forge version 0.1.0 (v0.1.0-299-gfb04716b+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2018-2020 Jonas Bernoulli <jonas@bernoul.li>
@@ -612,13 +612,18 @@ Forge adds the following two functions to ~magit-status-sections-hook~:
   This command toggles whether the above two functions list recently
   closed issues in the current buffer.
 
-The following two functions are also suitable for
+The following three functions are also suitable for
 ~magit-status-sections-hook~:
 
 - Function: forge-insert-assigned-pullreqs
 
   This function inserts a list of open pull-requests that are assigned
   to you.
+
+- Function: forge-insert-requested-pullreqs
+
+  This function inserts a list of open pull-requests that are awaiting
+  your review.
 
 - Function: forge-insert-assigned-issues
 

--- a/docs/forge.texi
+++ b/docs/forge.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Forge User and Developer Manual
-@subtitle for version 0.1.0 (v0.1.0-297-gb8baf139+1)
+@subtitle for version 0.1.0 (v0.1.0-299-gfb04716b+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -48,7 +48,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 @noindent
-This manual is for Forge version 0.1.0 (v0.1.0-297-gb8baf139+1).
+This manual is for Forge version 0.1.0 (v0.1.0-299-gfb04716b+1).
 
 @quotation
 Copyright (C) 2018-2020 Jonas Bernoulli <jonas@@bernoul.li>
@@ -850,13 +850,19 @@ This command toggles whether the above two functions list recently
 closed issues in the current buffer.
 @end deffn
 
-The following two functions are also suitable for
+The following three functions are also suitable for
 @code{magit-status-sections-hook}:
 
 @defun forge-insert-assigned-pullreqs
 
 This function inserts a list of open pull-requests that are assigned
 to you.
+@end defun
+
+@defun forge-insert-requested-pullreqs
+
+This function inserts a list of open pull-requests that are awaiting
+your review.
 @end defun
 
 @defun forge-insert-assigned-issues


### PR DESCRIPTION
This allows seeing a list of PRs for which someone has requested your review in a status
buffer (e.g. by adding it to `magit-status-sections-hook`). It builds on #241/#244.

It can, for instance, be used with https://github.com/charignon/github-review to review directly
from the magic status buffer.

I haven't updated the `docs/forge.texi` file.