### PR TITLE
Favour default-branch over master when creating a PR

### DIFF
--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -343,7 +343,8 @@ read an issue N to visit instead."
                          (if (magit-remote-branch-p d)
                              d
                            (magit-get-push-branch d t))))))
-         (remote  (oref (forge-get-repository t) remote))
+         (repo    (forge-get-repository t))
+         (remote  (oref repo remote))
          (targets (delete source (magit-list-remote-branch-names remote)))
          (target  (magit-completing-read
                    "Target branch" targets nil t nil 'magit-revision-history
@@ -353,7 +354,9 @@ read an issue N to visit instead."
                           (d (and d (if (magit-remote-branch-p d)
                                         d
                                       (magit-get-upstream-branch d))))
-                          (d (or d (concat remote "/master"))))
+                          (d (or d (concat remote "/"
+                                           (or (oref repo default-branch)
+                                               "master")))))
                      (car (member d targets))))))
     (list source target)))
 


### PR DESCRIPTION
Some repositories are not using `master` as their default branch. When there's
no upstream branch, I think it may be a good idea to fall back to the
`default-branch` for the repository before `master`.

I've also considered alternatives with [symbolic-ref of `HEAD`](https://stackoverflow.com/a/44750379/519827) and  [API]( https://stackoverflow.com/a/16501903/519827), yet given the simplicity of the solution in the b3de608 I decided to give it a shot. Please let me know what you think.