### PR TITLE
Convert (oset obj key val) to (setf (oref obj key) val)

### DIFF
--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -97,7 +97,7 @@ If pulling is too slow, then also consider setting the Git variable
            (format "Always pull all of %s/%s's topics going forward?"
                    (oref repo owner)
                    (oref repo name)))
-          (oset repo selective-p nil)
+          (setf (oref repo selective-p) nil)
         (user-error "Abort")))
     (setq forge--mode-line-buffer (current-buffer))
     (when-let ((remote  (oref repo remote))
@@ -129,7 +129,7 @@ If pulling is too slow, then also consider setting the Git variable
   (forge--msg repo t t "Pulling from REPO is not supported"))
 
 (cl-defmethod forge--pull ((repo forge-unusedapi-repository) _until)
-  (oset repo sparse-p nil)
+  (setf (oref repo sparse-p) nil)
   (magit-git-fetch (oref repo remote) (magit-fetch-arguments)))
 
 (defun forge--git-fetch (buf dir repo)
@@ -480,7 +480,7 @@ topic N and modify that instead."
   (interactive
    (let ((n (forge-read-topic "Edit marks of")))
      (list n (forge-read-marks "Marks: " (forge-get-topic n)))))
-  (oset (forge-get-topic n) marks marks)
+  (setf (oref (forge-get-topic n) marks) marks)
   (magit-refresh))
 
 (defun forge-edit-topic-assignees (n)
@@ -742,7 +742,7 @@ information."
                         (delete mark value)
                       (cons mark value)))
              (marks (forge-sql [:select [name id] :from mark])))
-        (oset topic marks (--map (cadr (assoc it marks)) value))
+        (setf (oref topic marks) (--map (cadr (assoc it marks)) value))
         (magit-refresh))
     (user-error "There is no topic at point")))
 
@@ -827,12 +827,12 @@ pull individual topics when the user invokes `forge-pull-topic'."
   (if (forge-get-repository url nil 'full)
       (user-error "%s is already tracked in Forge database" url)
     (let ((repo (forge-get-repository url nil 'create)))
-      (oset repo sparse-p nil)
+      (setf (oref repo sparse-p) nil)
       (magit-read-char-case "Pull " nil
         (?a "[a]ll topics"
             (forge-pull repo))
         (?i "[i]ndividual topics (useful for casual contributors)"
-            (oset repo selective-p t))))))
+            (setf (oref repo selective-p) t))))))
 
 ;;;###autoload
 (defun forge-add-user-repositories (host user)

--- a/lisp/forge-github.el
+++ b/lisp/forge-github.el
@@ -73,7 +73,7 @@
            (forge--update-issues     repo .issues t)
            (forge--update-pullreqs   repo .pullRequests t)
            (forge--update-revnotes   repo .commitComments))
-         (oset repo sparse-p nil))
+         (setf (oref repo sparse-p) nil))
        (forge--msg repo t t   "Storing REPO")
        (cond
         (callback (funcall callback))
@@ -114,22 +114,22 @@
 
 (cl-defmethod forge--update-repository ((repo forge-github-repository) data)
   (let-alist data
-    (oset repo created        .createdAt)
-    (oset repo updated        .updatedAt)
-    (oset repo pushed         .pushedAt)
-    (oset repo parent         .parent.nameWithOwner)
-    (oset repo description    .description)
-    (oset repo homepage       (and (not (equal .homepageUrl "")) .homepageUrl))
-    (oset repo default-branch .defaultBranchRef.name)
-    (oset repo archived-p     .isArchived)
-    (oset repo fork-p         .isFork)
-    (oset repo locked-p       .isLocked)
-    (oset repo mirror-p       .isMirror)
-    (oset repo private-p      .isPrivate)
-    (oset repo issues-p       .hasIssuesEnabled)
-    (oset repo wiki-p         .hasWikiEnabled)
-    (oset repo stars          .stargazers.totalCount)
-    (oset repo watchers       .watchers.totalCount)))
+    (setf (oref repo created)        .createdAt)
+    (setf (oref repo updated)        .updatedAt)
+    (setf (oref repo pushed)         .pushedAt)
+    (setf (oref repo parent)         .parent.nameWithOwner)
+    (setf (oref repo description)    .description)
+    (setf (oref repo homepage)       (and (not (equal .homepageUrl "")) .homepageUrl))
+    (setf (oref repo default-branch) .defaultBranchRef.name)
+    (setf (oref repo archived-p)     .isArchived)
+    (setf (oref repo fork-p)         .isFork)
+    (setf (oref repo locked-p)       .isLocked)
+    (setf (oref repo mirror-p)       .isMirror)
+    (setf (oref repo private-p)      .isPrivate)
+    (setf (oref repo issues-p)       .hasIssuesEnabled)
+    (setf (oref repo wiki-p)         .hasWikiEnabled)
+    (setf (oref repo stars)          .stargazers.totalCount)
+    (setf (oref repo watchers)       .watchers.totalCount)))
 
 (cl-defmethod forge--update-issues ((repo forge-github-repository) data bump)
   (emacsql-with-transaction (forge-db)
@@ -145,20 +145,20 @@
                          (forge-issue :id         issue-id
                                       :repository (oref repo id)
                                       :number     .number)))))
-        (oset issue state      (pcase-exhaustive .state
-                                 ("CLOSED" 'closed)
-                                 ("OPEN"   'open)))
-        (oset issue author     .author.login)
-        (oset issue title      .title)
-        (oset issue created    .createdAt)
-        (oset issue updated    (cond (bump (or .updatedAt .createdAt))
-                                     ((slot-boundp issue 'updated)
-                                      (oref issue updated))
-                                     (t "0")))
-        (oset issue closed     .closedAt)
-        (oset issue locked-p   .locked)
-        (oset issue milestone  .milestone)
-        (oset issue body       (forge--sanitize-string .body))
+        (setf (oref issue state)      (pcase-exhaustive .state
+                                        ("CLOSED" 'closed)
+                                        ("OPEN"   'open)))
+        (setf (oref issue author)     .author.login)
+        (setf (oref issue title)      .title)
+        (setf (oref issue created)    .createdAt)
+        (setf (oref issue updated)    (cond (bump (or .updatedAt .createdAt))
+                                            ((slot-boundp issue 'updated)
+                                             (oref issue updated))
+                                            (t "0")))
+        (setf (oref issue closed)     .closedAt)
+        (setf (oref issue locked-p)   .locked)
+        (setf (oref issue milestone)  .milestone)
+        (setf (oref issue body)       (forge--sanitize-string .body))
         .databaseId ; Silence Emacs 25 byte-compiler.
         (dolist (c .comments)
           (let-alist c
@@ -192,29 +192,29 @@
                            (forge-pullreq :id           pullreq-id
                                           :repository   (oref repo id)
                                           :number       .number)))))
-        (oset pullreq state        (pcase-exhaustive .state
-                                     ("MERGED" 'merged)
-                                     ("CLOSED" 'closed)
-                                     ("OPEN"   'open)))
-        (oset pullreq author       .author.login)
-        (oset pullreq title        .title)
-        (oset pullreq created      .createdAt)
-        (oset pullreq updated      (cond (bump (or .updatedAt .createdAt))
-                                         ((slot-boundp pullreq 'updated)
-                                          (oref pullreq updated))
-                                         (t "0")))
-        (oset pullreq closed       .closedAt)
-        (oset pullreq merged       .mergedAt)
-        (oset pullreq locked-p     .locked)
-        (oset pullreq editable-p   .maintainerCanModify)
-        (oset pullreq cross-repo-p .isCrossRepository)
-        (oset pullreq base-ref     .baseRef.name)
-        (oset pullreq base-repo    .baseRef.repository.nameWithOwner)
-        (oset pullreq head-ref     .headRef.name)
-        (oset pullreq head-user    .headRef.repository.owner.login)
-        (oset pullreq head-repo    .headRef.repository.nameWithOwner)
-        (oset pullreq milestone    .milestone)
-        (oset pullreq body         (forge--sanitize-string .body))
+        (setf (oref pullreq state)        (pcase-exhaustive .state
+                                            ("MERGED" 'merged)
+                                            ("CLOSED" 'closed)
+                                            ("OPEN"   'open)))
+        (setf (oref pullreq author)       .author.login)
+        (setf (oref pullreq title)        .title)
+        (setf (oref pullreq created)      .createdAt)
+        (setf (oref pullreq updated)      (cond (bump (or .updatedAt .createdAt))
+                                                ((slot-boundp pullreq 'updated)
+                                                 (oref pullreq updated))
+                                                (t "0")))
+        (setf (oref pullreq closed)       .closedAt)
+        (setf (oref pullreq merged)       .mergedAt)
+        (setf (oref pullreq locked-p)     .locked)
+        (setf (oref pullreq editable-p)   .maintainerCanModify)
+        (setf (oref pullreq cross-repo-p) .isCrossRepository)
+        (setf (oref pullreq base-ref)     .baseRef.name)
+        (setf (oref pullreq base-repo)    .baseRef.repository.nameWithOwner)
+        (setf (oref pullreq head-ref)     .headRef.name)
+        (setf (oref pullreq head-user)    .headRef.repository.owner.login)
+        (setf (oref pullreq head-repo)    .headRef.repository.nameWithOwner)
+        (setf (oref pullreq milestone)    .milestone)
+        (setf (oref pullreq body)         (forge--sanitize-string .body))
         .databaseId ; Silence Emacs 25 byte-compiler.
         (dolist (p .comments)
           (let-alist p
@@ -257,7 +257,7 @@
        t))))
 
 (cl-defmethod forge--update-assignees ((repo forge-github-repository) data)
-  (oset repo assignees
+  (setf (oref repo assignees)
         (with-slots (id) repo
           (mapcar (lambda (row)
                     (let-alist row
@@ -268,7 +268,7 @@
                   (delete-dups data)))))
 
 (cl-defmethod forge--update-forks ((repo forge-github-repository) data)
-  (oset repo forks
+  (setf (oref repo forks)
         (with-slots (id) repo
           (mapcar (lambda (row)
                     (let-alist row
@@ -282,7 +282,7 @@
                   (delete-dups data)))))
 
 (cl-defmethod forge--update-labels ((repo forge-github-repository) data)
-  (oset repo labels
+  (setf (oref repo labels)
         (with-slots (id) repo
           (mapcar (lambda (row)
                     (let-alist row
@@ -340,11 +340,11 @@
                    (pcase-dolist (`(,key ,repo ,query ,obj) notifs)
                      (closql-insert (forge-db) obj)
                      (when query
-                       (oset (funcall (if (eq (oref obj type) 'issue)
-                                          #'forge--update-issue
-                                        #'forge--update-pullreq)
-                                      repo (cdr (cadr (assq key result))) nil)
-                             unread-p (oref obj unread-p)))))
+                       (setf (oref (funcall (if (eq (oref obj type) 'issue)
+                                                #'forge--update-issue
+                                              #'forge--update-pullreq)
+                                            repo (cdr (cadr (assq key result))) nil)
+                                   unread-p) (oref obj unread-p)))))
                  (forge--msg nil t t "Storing notifications")
                  (when callback
                    (funcall callback)))))
@@ -395,9 +395,9 @@
 
 (cl-defmethod forge-topic-mark-read ((_ forge-github-repository) topic)
   (when (oref topic unread-p)
-    (oset topic unread-p nil)
+    (setf (oref topic unread-p) nil)
     (when-let ((notif (forge-get-notification topic)))
-      (oset topic unread-p nil)
+      (setf (oref topic unread-p) nil)
       (forge--ghub-patch notif "/notifications/threads/:thread-id"))))
 
 ;;;; Miscellaneous

--- a/lisp/forge-gitlab.el
+++ b/lisp/forge-gitlab.el
@@ -89,7 +89,7 @@ it is all or nothing.")
                       (forge--update-labels     repo .labels)
                       (dolist (v .issues)   (forge--update-issue repo v))
                       (dolist (v .pullreqs) (forge--update-pullreq repo v))
-                      (oset repo sparse-p nil))
+                      (setf (oref repo sparse-p) nil))
                     (forge--msg repo t t "Storing REPO")
                     (forge--git-fetch buf dir repo))))))))
     (funcall cb cb)))
@@ -101,22 +101,22 @@ it is all or nothing.")
 
 (cl-defmethod forge--update-repository ((repo forge-gitlab-repository) data)
   (let-alist data
-    (oset repo created        .created_at)
-    (oset repo updated        .last_activity_at)
-    (oset repo pushed         nil)
-    (oset repo parent         .forked_from_project.path_with_namespace)
-    (oset repo description    .description)
-    (oset repo homepage       nil)
-    (oset repo default-branch .default_branch)
-    (oset repo archived-p     .archived)
-    (oset repo fork-p         (and .forked_from_project.path_with_namespace t))
-    (oset repo locked-p       nil)
-    (oset repo mirror-p       .mirror)
-    (oset repo private-p      (equal .visibility "private"))
-    (oset repo issues-p       .issues_enabled)
-    (oset repo wiki-p         .wiki_enabled)
-    (oset repo stars          .star_count)
-    (oset repo watchers       .star_count)))
+    (setf (oref repo created)        .created_at)
+    (setf (oref repo updated)        .last_activity_at)
+    (setf (oref repo pushed)         nil)
+    (setf (oref repo parent)         .forked_from_project.path_with_namespace)
+    (setf (oref repo description)    .description)
+    (setf (oref repo homepage)       nil)
+    (setf (oref repo default-branch) .default_branch)
+    (setf (oref repo archived-p)     .archived)
+    (setf (oref repo fork-p)         (and .forked_from_project.path_with_namespace t))
+    (setf (oref repo locked-p)       nil)
+    (setf (oref repo mirror-p)       .mirror)
+    (setf (oref repo private-p)      (equal .visibility "private"))
+    (setf (oref repo issues-p)       .issues_enabled)
+    (setf (oref repo wiki-p)         .wiki_enabled)
+    (setf (oref repo stars)          .star_count)
+    (setf (oref repo watchers)       .star_count)))
 
 (cl-defmethod forge--split-url-path
   ((_class (subclass forge-gitlab-repository)) path)
@@ -351,7 +351,7 @@ it is all or nothing.")
                 (funcall callback callback (cons 'assignees value)))))
 
 (cl-defmethod forge--update-assignees ((repo forge-gitlab-repository) data)
-  (oset repo assignees
+  (setf (oref repo assignees)
         (with-slots (id) repo
           (mapcar (lambda (row)
                     (let-alist row
@@ -373,7 +373,7 @@ it is all or nothing.")
                 (funcall callback callback (cons 'forks value)))))
 
 (cl-defmethod forge--update-forks ((repo forge-gitlab-repository) data)
-  (oset repo forks
+  (setf (oref repo forks)
         (with-slots (id) repo
           (mapcar (lambda (row)
                     (let-alist row
@@ -394,7 +394,7 @@ it is all or nothing.")
                 (funcall callback callback (cons 'labels value)))))
 
 (cl-defmethod forge--update-labels ((repo forge-gitlab-repository) data)
-  (oset repo labels
+  (setf (oref repo labels)
         (with-slots (id) repo
           (mapcar (lambda (row)
                     (let-alist row

--- a/lisp/forge-post.el
+++ b/lisp/forge-post.el
@@ -58,7 +58,7 @@
                                'pullreq-post-url-format)))))
 
 (cl-defmethod forge-browse :after ((post forge-post))
-  (oset (forge-get-topic post) unread-p nil))
+  (setf (oref (forge-get-topic post) unread-p) nil))
 
 ;;; Sections
 

--- a/lisp/forge-repo.el
+++ b/lisp/forge-repo.el
@@ -150,7 +150,7 @@ repository, if any."
           (if-let ((url (and remote
                              (magit-git-string "remote" "get-url" remote))))
               (when-let ((repo (forge-get-repository url remote demand)))
-                (oset repo worktree (magit-toplevel))
+                (setf (oref repo worktree) (magit-toplevel))
                 repo)
             (when (memq demand forge--signal-no-entry)
               (error
@@ -182,9 +182,9 @@ Return the repository identified by HOST, OWNER and NAME."
                                     forge owner name)))
                (obj (and row (closql--remake-instance class (forge-db) row))))
           (when obj
-            (oset obj apihost apihost)
-            (oset obj githost githost)
-            (oset obj remote  remote))
+            (setf (oref obj apihost) apihost)
+            (setf (oref obj githost) githost)
+            (setf (oref obj remote) remote))
           (cond ((and (eq demand t)
                       (or (not obj)
                           (oref obj sparse-p)))

--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -266,7 +266,7 @@ This variable has to be customized before `forge' is loaded."
   (forge-topic-mark-read (forge-get-repository topic) topic))
 
 (cl-defmethod forge-topic-mark-read ((_ forge-repository) topic)
-  (oset topic unread-p nil))
+  (setf (oref topic unread-p) nil))
 
 (defun forge--sanitize-string (string)
   ;; For Gitlab this may also be nil.
@@ -401,7 +401,7 @@ identifier."
       (dolist (post (cons topic (oref topic posts)))
         (with-slots (author created body) post
           (magit-insert-section section (post post)
-            (oset section heading-highlight-face
+            (setf (oref section heading-highlight-face)
                   'magit-diff-hunk-heading-highlight)
             (let ((heading
                    (format-spec


### PR DESCRIPTION
oset is obselete as of Emacs 28.1.

See https://github.com/magit/magit/issues/4105.
