### PR TITLE
forge-pkg.el: Add homepage URL

### DIFF
--- a/forge-pkg.el
+++ b/forge-pkg.el
@@ -13,4 +13,5 @@
     ;; also remove the related kludge from Forge's Melpa recipe.
     (magit          "20190408")
     (markdown-mode  "2.3")
-    (transient      "0.1.0")))
+    (transient      "0.1.0"))
+  :url "https://github.com/magit/forge")


### PR DESCRIPTION
When browsing MELPA via `list-packages`, there is no homepage URL for
forge. I *think* this is how one adds an URL to the `define-package`
form, as suggested by this
[GitHub search](https://github.com/search?l=Emacs+Lisp&q=define-package+https%3A%2F%2F&type=Code).
