### PR TITLE
Authored lists and sections

### DIFF
--- a/docs/forge.org
+++ b/docs/forge.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Forge: (forge).
 #+TEXINFO_DIR_DESC: Access Git Forges from Magit
-#+SUBTITLE: for version 0.1.0 (v0.1.0-320-g639ce512+1)
+#+SUBTITLE: for version 0.1.0 (v0.1.0-327-gbbecff72+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:4 toc:2
@@ -20,7 +20,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 #+TEXINFO: @noindent
-This manual is for Forge version 0.1.0 (v0.1.0-320-g639ce512+1).
+This manual is for Forge version 0.1.0 (v0.1.0-327-gbbecff72+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2018-2020 Jonas Bernoulli <jonas@bernoul.li>
@@ -675,6 +675,16 @@ dedicated buffers:
 
   This command lists pull-requests of the current repository that are
   awaiting your review in a separate buffer.
+
+- Command: forge-list-authored-pullreqs
+
+  This command lists the current repository's open issues that are
+  authored by you in a separate buffer.
+
+- Command: forge-list-authored-issues
+
+  This command lists the current repository's open pull-requests that
+  are authored by you in a separate buffer.
 
 - Command: forge-list-owned-pullreqs
 

--- a/docs/forge.org
+++ b/docs/forge.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Forge: (forge).
 #+TEXINFO_DIR_DESC: Access Git Forges from Magit
-#+SUBTITLE: for version 0.1.0 (v0.1.0-327-gbbecff72+1)
+#+SUBTITLE: for version 0.1.0 (v0.1.0-328-g3e707156+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:4 toc:2
@@ -20,7 +20,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 #+TEXINFO: @noindent
-This manual is for Forge version 0.1.0 (v0.1.0-327-gbbecff72+1).
+This manual is for Forge version 0.1.0 (v0.1.0-328-g3e707156+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2018-2020 Jonas Bernoulli <jonas@bernoul.li>
@@ -634,9 +634,19 @@ The following three functions are also suitable for
   This function inserts a list of open pull-requests that are awaiting
   your review.
 
+- Function: forge-insert-authored-pullreqs
+
+  This function inserts a list of open pull-requests that are authored
+  by you.
+
 - Function: forge-insert-assigned-issues
 
   This function inserts a list of open issues that are assigned to
+  you.
+
+- Function: forge-insert-authored-issues
+
+  This function inserts a list of open issues that are authored by
   you.
 
 The following commands list repositories, notifications and topics in

--- a/docs/forge.texi
+++ b/docs/forge.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Forge User and Developer Manual
-@subtitle for version 0.1.0 (v0.1.0-320-g639ce512+1)
+@subtitle for version 0.1.0 (v0.1.0-327-gbbecff72+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -48,7 +48,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 @noindent
-This manual is for Forge version 0.1.0 (v0.1.0-320-g639ce512+1).
+This manual is for Forge version 0.1.0 (v0.1.0-327-gbbecff72+1).
 
 @quotation
 Copyright (C) 2018-2020 Jonas Bernoulli <jonas@@bernoul.li>
@@ -950,6 +950,20 @@ are assigned to you in a separate buffer.
 
 This command lists pull-requests of the current repository that are
 awaiting your review in a separate buffer.
+@end deffn
+
+@cindex forge-list-authored-pullreqs
+@deffn Command forge-list-authored-pullreqs
+
+This command lists the current repository's open issues that are
+authored by you in a separate buffer.
+@end deffn
+
+@cindex forge-list-authored-issues
+@deffn Command forge-list-authored-issues
+
+This command lists the current repository's open pull-requests that
+are authored by you in a separate buffer.
 @end deffn
 
 @cindex forge-list-owned-pullreqs

--- a/docs/forge.texi
+++ b/docs/forge.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Forge User and Developer Manual
-@subtitle for version 0.1.0 (v0.1.0-327-gbbecff72+1)
+@subtitle for version 0.1.0 (v0.1.0-328-g3e707156+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -48,7 +48,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 @noindent
-This manual is for Forge version 0.1.0 (v0.1.0-327-gbbecff72+1).
+This manual is for Forge version 0.1.0 (v0.1.0-328-g3e707156+1).
 
 @quotation
 Copyright (C) 2018-2020 Jonas Bernoulli <jonas@@bernoul.li>
@@ -892,9 +892,21 @@ This function inserts a list of open pull-requests that are awaiting
 your review.
 @end defun
 
+@defun forge-insert-authored-pullreqs
+
+This function inserts a list of open pull-requests that are authored
+by you.
+@end defun
+
 @defun forge-insert-assigned-issues
 
 This function inserts a list of open issues that are assigned to
+you.
+@end defun
+
+@defun forge-insert-authored-issues
+
+This function inserts a list of open issues that are authored by
 you.
 @end defun
 

--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -55,10 +55,12 @@ for a repository using the command `forge-add-pullreq-refspec'."
     ("l p" "pull-requests" forge-list-pullreqs)
     ("l n" "notifications" forge-list-notifications)
     ("l r" "repositories"  forge-list-repositories)
-    (7 "l a" "awaiting review"     forge-list-requested-reviews)
-    (7 "o i" "owned issues"        forge-list-owned-issues)
-    (7 "o p" "owned pull-requests" forge-list-owned-pullreqs)
-    (7 "o r" "owned repositories"  forge-list-owned-repositories)]
+    (7 "l a" "awaiting review"        forge-list-requested-reviews)
+    (7 "m i" "authored issues"        forge-list-authored-issues)
+    (7 "m p" "authored pull-requests" forge-list-authored-pullreqs)
+    (7 "o i" "owned issues"           forge-list-owned-issues)
+    (7 "o p" "owned pull-requests"    forge-list-owned-pullreqs)
+    (7 "o r" "owned repositories"     forge-list-owned-repositories)]
    ["Create"
     ("c i" "issue"         forge-create-issue)
     ("c p" "pull-request"  forge-create-pullreq)

--- a/lisp/forge-issue.el
+++ b/lisp/forge-issue.el
@@ -192,6 +192,27 @@ Also see option `forge-topic-list-limit'."
            (oref repo id)
            (ghub--username repo))))
 
+(defun forge-insert-authored-issues ()
+  "Insert a list of open issues that are authored to you."
+  (when-let ((repo (forge-get-repository nil)))
+    (unless (oref repo sparse-p)
+      (forge-insert-topics "Authored issues"
+                           (forge--ls-authored-issues repo)
+                           (forge--topic-type-prefix repo 'issue)))))
+
+(defun forge--ls-authored-issues (repo)
+  (mapcar (lambda (row)
+            (closql--remake-instance 'forge-issue (forge-db) row))
+          (forge-sql
+           [:select $i1 :from [issue]
+            :where (and (= issue:repository $s2)
+                        (= issue:author     $s3)
+                        (isnull issue:closed))
+            :order-by [(desc updated)]]
+           (vconcat (closql--table-columns (forge-db) 'issue t))
+           (oref repo id)
+           (ghub--username repo))))
+
 ;;; _
 (provide 'forge-issue)
 ;;; forge-issue.el ends here

--- a/lisp/forge-list.el
+++ b/lisp/forge-list.el
@@ -333,6 +333,36 @@ Only Github is supported for now."
                  (vconcat (mapcar #'car forge-owned-accounts))
                  (vconcat forge-owned-blacklist)))))
 
+;;;###autoload
+(defun forge-list-authored-pullreqs (id)
+  "List open pull-requests of the current repository that are authored by you.
+List them in a separate buffer."
+  (interactive (list (oref (forge-get-repository t) id)))
+  (forge-topic-list-setup #'forge-pullreq-list-mode id nil nil
+    (lambda ()
+      (forge-sql [:select $i1 :from [pullreq]
+                          :where (and (= pullreq:repository       $s2)
+                                      (= pullreq:author           $s3)
+                                      (isnull pullreq:closed))
+                          :order-by [(desc updated)]]
+                 (forge--tablist-columns-vector 'pullreq)
+                 id (ghub--username (forge-get-repository (list :id id)))))))
+
+;;;###autoload
+(defun forge-list-authored-issues (id)
+  "List open issues from the current repository that are authored by you.
+List them in a separate buffer."
+  (interactive (list (oref (forge-get-repository t) id)))
+  (forge-topic-list-setup #'forge-pullreq-list-mode id nil nil
+    (lambda ()
+      (forge-sql [:select $i1 :from [issue]
+                          :where (and (= issue:repository       $s2)
+                                      (= issue:author           $s3)
+                                      (isnull issue:closed))
+                          :order-by [(desc updated)]]
+                 (forge--tablist-columns-vector 'issue)
+                 id (ghub--username (forge-get-repository (list :id id)))))))
+
 ;;;; Repository
 
 ;;;###autoload


### PR DESCRIPTION
Quick PR to add commands/sections that are useful to people who need to track issues/prs that they have created. Please note that I wrote the texi documentation before I realised it was meant to be generated from org. Hopefully it'll match up but a maintainer might want to do the conversion before merge.

Adds two new section commands:

* `forge-insert-authored-pullreqs`
* `forge-insert-authored-issues`

And two new list commands on the same theme:

* `forge-list-authored-pullreqs`
* `forge-list-authored-issues`