### PR TITLE
Allow toggling Forge sections

### DIFF
--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -67,7 +67,9 @@ for a repository using the command `forge-add-pullreq-refspec'."
     ("c f" "fork or remote" forge-fork)]]
   [["Configure"
     ("a" "add repository to database" forge-add-repository)
-    ("r" "forge.repository" forge-forge.remote)]])
+    ("r" "forge.repository" forge-forge.remote)
+    ("t" forge-forge.topics)]])
+
 
 ;;; Pull
 
@@ -803,6 +805,19 @@ is added anyway.  Currently this only supports Github and Gitlab."
   :variable "forge.remote"
   :choices 'magit-list-remotes
   :default "origin")
+
+(defvar-local forge-display-topics t
+  "Whether the Forge topics are inserted in the Magit status buffer upon refresh.")
+
+(transient-define-suffix forge-forge.topics ()
+  :transient nil
+  :description (lambda ()
+                 (if forge-display-topics
+                     "hide topics"
+                   "display topics"))
+  "Hides/displays Forge topics in the Magit status buffer upon refresh."
+  (interactive)
+  (setq forge-display-topics (not forge-display-topics)))
 
 ;;;###autoload
 (defun forge-list-notifications ()

--- a/lisp/forge-pullreq.el
+++ b/lisp/forge-pullreq.el
@@ -246,7 +246,7 @@ yourself, in which case you probably should not reset either.
   "Insert a list of mostly recent and/or open pull-requests.
 Also see option `forge-topic-list-limit'."
   (when-let ((repo (forge-get-repository nil)))
-    (unless (oref repo sparse-p)
+    (when (and forge-display-topics (not (oref repo sparse-p)))
       (forge-insert-topics "Pull requests"
                            (forge-ls-recent-topics repo 'pullreq)
                            (forge--topic-type-prefix repo 'pullreq)))))


### PR DESCRIPTION
Depending on the size of the notifications for the repo, the redisplay of the magit-status buffer is noticeably slower (in my particular case, the `magit-insert` hooks for PRs and issues regularly spend more than 2s each).

This PR allows the user to toggle redisplay for these sections as needed, to avoid this performance hit.

(As an aside - thanks for all your work on Magit & Emacs in general. Big fan.)