### PR TITLE
Improve setup docs

### DIFF
--- a/docs/forge.org
+++ b/docs/forge.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Forge: (forge).
 #+TEXINFO_DIR_DESC: Access Git Forges from Magit
-#+SUBTITLE: for version 0.1.0 (v0.1.0-332-g794582b6+1)
+#+SUBTITLE: for version 0.1.0 (v0.1.0-333-g93c7477e+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:4 toc:2
@@ -20,7 +20,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 #+TEXINFO: @noindent
-This manual is for Forge version 0.1.0 (v0.1.0-332-g794582b6+1).
+This manual is for Forge version 0.1.0 (v0.1.0-333-g93c7477e+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2018-2020 Jonas Bernoulli <jonas@bernoul.li>
@@ -255,6 +255,33 @@ Or if you use ~use-package~:
     :after magit)
 #+END_SRC
 
+** Token Creation
+
+Forge uses the Ghub package to access the APIs of supported Git
+forges.  How this works and how to create and store a token is
+documented in [[info:ghub#Getting Started]].
+
+Ghub used to provide a setup wizard, but that had to be removed for
+reasons given in the manual just mentioned.  Nowadays there is no way
+around reading the documentation and doing this manually I am afraid.
+
+  Forge requires the following token scopes.
+
+- For Github these scopes are required.
+
+  - ~repo~ grants full read/write access to private and public
+    repositories.
+  - ~user~ grants access to profile information.
+  - ~read:org~ grants read-only access to organization membership.
+
+  More information about these and other scopes can be found at
+  https://docs.github.com/en/developers/apps/scopes-for-oauth-apps.
+
+- For Gitlab instances ~api~ is the only required scope.  It gives read
+  and write access to everything.  The Gitlab API provides more
+  fine-grained scopes for read-only access, but when any write access
+  at all is required, then it is all or nothing.
+
 ** Initial Pull
 
 To start using Forge in a certain repository visit the Magit status
@@ -282,33 +309,6 @@ Subsequent fetches are much faster.
 Fetching issues from Github is much faster than fetching from other
 forges because making a handful of GraphQL requests is much faster
 than making hundreds of REST requests.
-
-** Token Creation
-
-Forge uses the Ghub package to access the APIs of supported Git
-forges.  How this works and how to create and store a token is
-documented in [[info:ghub#Getting Started]].
-
-Ghub used to provide a setup wizard, but that had to be removed for
-reasons given in the manual just mentioned.  Nowadays there is no way
-around reading the documentation and doing this manually I am afraid.
-
-  Forge requires the following token scopes.
-
-- For Github these scopes are required.
-
-  - ~repo~ grants full read/write access to private and public
-    repositories.
-  - ~user~ grants access to profile information.
-  - ~read:org~ grants read-only access to organization membership.
-
-  More information about these and other scopes can be found at
-  https://docs.github.com/en/developers/apps/scopes-for-oauth-apps.
-
-- For Gitlab instances ~api~ is the only required scope.  It gives read
-  and write access to everything.  The Gitlab API provides more
-  fine-grained scopes for read-only access, but when any write access
-  at all is required, then it is all or nothing.
 
 ** Repository Detection
 

--- a/docs/forge.org
+++ b/docs/forge.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Forge: (forge).
 #+TEXINFO_DIR_DESC: Access Git Forges from Magit
-#+SUBTITLE: for version 0.1.0 (v0.1.0-330-gaa994f79+1)
+#+SUBTITLE: for version 0.1.0 (v0.1.0-331-ge2bae40e+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:4 toc:2
@@ -20,7 +20,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 #+TEXINFO: @noindent
-This manual is for Forge version 0.1.0 (v0.1.0-330-gaa994f79+1).
+This manual is for Forge version 0.1.0 (v0.1.0-331-ge2bae40e+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2018-2020 Jonas Bernoulli <jonas@bernoul.li>
@@ -224,7 +224,7 @@ caveats you should be aware of:
 
 - Fetched information is stored in a database.  The table schemata of
   that database have not been finalized yet.  Until that has happened
-  it will occasionally have to be discard.  That isn't such a huge
+  it will occasionally have to be discarded.  That isn't such a huge
   deal because for now the database does not contain any information
   that cannot simply be fetched again, see [[*Initial Pull]].
 

--- a/docs/forge.org
+++ b/docs/forge.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Forge: (forge).
 #+TEXINFO_DIR_DESC: Access Git Forges from Magit
-#+SUBTITLE: for version 0.1.0 (v0.1.0-334-gd86f7b2a+1)
+#+SUBTITLE: for version 0.1.0 (v0.1.0-335-g9d1fd563+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:4 toc:2
@@ -20,7 +20,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 #+TEXINFO: @noindent
-This manual is for Forge version 0.1.0 (v0.1.0-334-gd86f7b2a+1).
+This manual is for Forge version 0.1.0 (v0.1.0-335-g9d1fd563+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2018-2020 Jonas Bernoulli <jonas@bernoul.li>
@@ -333,11 +333,11 @@ remotes are tried.
 If you do not follow the naming convention, then you have to inform
 Forge about that by setting the Git variable ~forge.remote~ to the name
 that you instead use for upstream remotes.  For example, to use the
-upstream remote named "main":
+upstream remote named "upstream":
 
 #+BEGIN_SRC shell
   cd /path/to/repo
-  git config --local forge.remote main
+  git config --local forge.remote upstream
 #+END_SRC
 
 If this variable is set, then Forge uses the remote by that name, if

--- a/docs/forge.org
+++ b/docs/forge.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Forge: (forge).
 #+TEXINFO_DIR_DESC: Access Git Forges from Magit
-#+SUBTITLE: for version 0.1.0 (v0.1.0-331-ge2bae40e+1)
+#+SUBTITLE: for version 0.1.0 (v0.1.0-332-g794582b6+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:4 toc:2
@@ -20,7 +20,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 #+TEXINFO: @noindent
-This manual is for Forge version 0.1.0 (v0.1.0-331-ge2bae40e+1).
+This manual is for Forge version 0.1.0 (v0.1.0-332-g794582b6+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2018-2020 Jonas Bernoulli <jonas@bernoul.li>
@@ -263,10 +263,7 @@ you can use ~M-x forge-add-repository~, which makes it possible to add a
 forge repository without pulling all topics and even without having to
 clone the respective Git repository.
 
-When adding the first repository from https://github.com to your local
-database you will be guided through the process of creating the API
-token.  For other forges, as well as for other Github instances, some
-additional setup is required *before* you can add the first repository.
+You must set up a token *before* you can add the first repository.
 See [[*Token Creation]].
 
 The first time ~forge-pull~ is run in a repository, an entry for that

--- a/docs/forge.org
+++ b/docs/forge.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Forge: (forge).
 #+TEXINFO_DIR_DESC: Access Git Forges from Magit
-#+SUBTITLE: for version 0.1.0 (v0.1.0-333-g93c7477e+1)
+#+SUBTITLE: for version 0.1.0 (v0.1.0-334-gd86f7b2a+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:4 toc:2
@@ -20,7 +20,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 #+TEXINFO: @noindent
-This manual is for Forge version 0.1.0 (v0.1.0-333-g93c7477e+1).
+This manual is for Forge version 0.1.0 (v0.1.0-334-gd86f7b2a+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2018-2020 Jonas Bernoulli <jonas@bernoul.li>
@@ -332,11 +332,18 @@ remotes are tried.
 
 If you do not follow the naming convention, then you have to inform
 Forge about that by setting the Git variable ~forge.remote~ to the name
-that you instead use for upstream remotes.  If this variable is set,
-then Forge uses the remote by that name, if it exists, the same way
-it may have used ~origin~ if the the variable were undefined.  I.e. it
-does not fall through to try ~origin~ if no remote by your chosen name
-exists.
+that you instead use for upstream remotes.  For example, to use the
+upstream remote named "main":
+
+#+BEGIN_SRC shell
+  cd /path/to/repo
+  git config --local forge.remote main
+#+END_SRC
+
+If this variable is set, then Forge uses the remote by that name, if
+it exists, the same way it may have used ~origin~ if the the variable
+were undefined.  I.e. it does not fall through to try ~origin~ if no
+remote by your chosen name exists.
 
 Once the upstream remote has been determined, Forge looks it up in
 ~forge-alist~, using the host part of the URL as the key.  For example

--- a/docs/forge.texi
+++ b/docs/forge.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Forge User and Developer Manual
-@subtitle for version 0.1.0 (v0.1.0-330-gaa994f79+1)
+@subtitle for version 0.1.0 (v0.1.0-331-ge2bae40e+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -48,7 +48,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 @noindent
-This manual is for Forge version 0.1.0 (v0.1.0-330-gaa994f79+1).
+This manual is for Forge version 0.1.0 (v0.1.0-331-ge2bae40e+1).
 
 @quotation
 Copyright (C) 2018-2020 Jonas Bernoulli <jonas@@bernoul.li>
@@ -370,7 +370,7 @@ you have to create a token as described in @ref{Token Creation}.
 @item
 Fetched information is stored in a database.  The table schemata of
 that database have not been finalized yet.  Until that has happened
-it will occasionally have to be discard.  That isn't such a huge
+it will occasionally have to be discarded.  That isn't such a huge
 deal because for now the database does not contain any information
 that cannot simply be fetched again, see @ref{Initial Pull}.
 

--- a/docs/forge.texi
+++ b/docs/forge.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Forge User and Developer Manual
-@subtitle for version 0.1.0 (v0.1.0-334-gd86f7b2a+1)
+@subtitle for version 0.1.0 (v0.1.0-335-g9d1fd563+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -48,7 +48,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 @noindent
-This manual is for Forge version 0.1.0 (v0.1.0-334-gd86f7b2a+1).
+This manual is for Forge version 0.1.0 (v0.1.0-335-g9d1fd563+1).
 
 @quotation
 Copyright (C) 2018-2020 Jonas Bernoulli <jonas@@bernoul.li>
@@ -504,11 +504,11 @@ remotes are tried.
 If you do not follow the naming convention, then you have to inform
 Forge about that by setting the Git variable @code{forge.remote} to the name
 that you instead use for upstream remotes.  For example, to use the
-upstream remote named "main":
+upstream remote named "upstream":
 
 @example
 cd /path/to/repo
-git config --local forge.remote main
+git config --local forge.remote upstream
 @end example
 
 If this variable is set, then Forge uses the remote by that name, if

--- a/docs/forge.texi
+++ b/docs/forge.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Forge User and Developer Manual
-@subtitle for version 0.1.0 (v0.1.0-333-g93c7477e+1)
+@subtitle for version 0.1.0 (v0.1.0-334-gd86f7b2a+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -48,7 +48,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 @noindent
-This manual is for Forge version 0.1.0 (v0.1.0-333-g93c7477e+1).
+This manual is for Forge version 0.1.0 (v0.1.0-334-gd86f7b2a+1).
 
 @quotation
 Copyright (C) 2018-2020 Jonas Bernoulli <jonas@@bernoul.li>
@@ -503,11 +503,18 @@ remotes are tried.
 
 If you do not follow the naming convention, then you have to inform
 Forge about that by setting the Git variable @code{forge.remote} to the name
-that you instead use for upstream remotes.  If this variable is set,
-then Forge uses the remote by that name, if it exists, the same way
-it may have used @code{origin} if the the variable were undefined.  I.e. it
-does not fall through to try @code{origin} if no remote by your chosen name
-exists.
+that you instead use for upstream remotes.  For example, to use the
+upstream remote named "main":
+
+@example
+cd /path/to/repo
+git config --local forge.remote main
+@end example
+
+If this variable is set, then Forge uses the remote by that name, if
+it exists, the same way it may have used @code{origin} if the the variable
+were undefined.  I.e. it does not fall through to try @code{origin} if no
+remote by your chosen name exists.
 
 Once the upstream remote has been determined, Forge looks it up in
 @code{forge-alist}, using the host part of the URL as the key.  For example

--- a/docs/forge.texi
+++ b/docs/forge.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Forge User and Developer Manual
-@subtitle for version 0.1.0 (v0.1.0-331-ge2bae40e+1)
+@subtitle for version 0.1.0 (v0.1.0-332-g794582b6+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -48,7 +48,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 @noindent
-This manual is for Forge version 0.1.0 (v0.1.0-331-ge2bae40e+1).
+This manual is for Forge version 0.1.0 (v0.1.0-332-g794582b6+1).
 
 @quotation
 Copyright (C) 2018-2020 Jonas Bernoulli <jonas@@bernoul.li>
@@ -420,10 +420,7 @@ you can use @code{M-x forge-add-repository}, which makes it possible to add a
 forge repository without pulling all topics and even without having to
 clone the respective Git repository.
 
-When adding the first repository from @uref{https://github.com} to your local
-database you will be guided through the process of creating the API
-token.  For other forges, as well as for other Github instances, some
-additional setup is required @strong{before} you can add the first repository.
+You must set up a token @strong{before} you can add the first repository.
 See @ref{Token Creation}.
 
 The first time @code{forge-pull} is run in a repository, an entry for that

--- a/docs/forge.texi
+++ b/docs/forge.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Forge User and Developer Manual
-@subtitle for version 0.1.0 (v0.1.0-332-g794582b6+1)
+@subtitle for version 0.1.0 (v0.1.0-333-g93c7477e+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -48,7 +48,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 @noindent
-This manual is for Forge version 0.1.0 (v0.1.0-332-g794582b6+1).
+This manual is for Forge version 0.1.0 (v0.1.0-333-g93c7477e+1).
 
 @quotation
 Copyright (C) 2018-2020 Jonas Bernoulli <jonas@@bernoul.li>
@@ -82,8 +82,8 @@ General Public License for more details.
 
 Getting Started
 
-* Initial Pull::
 * Token Creation::
+* Initial Pull::
 * Repository Detection::
 
 Usage
@@ -406,39 +406,10 @@ Or if you use @code{use-package}:
 @end lisp
 
 @menu
-* Initial Pull::
 * Token Creation::
+* Initial Pull::
 * Repository Detection::
 @end menu
-
-@node Initial Pull
-@section Initial Pull
-
-To start using Forge in a certain repository visit the Magit status
-buffer for that repository and type @code{f y} (@code{forge-pull}).  Alternatively,
-you can use @code{M-x forge-add-repository}, which makes it possible to add a
-forge repository without pulling all topics and even without having to
-clone the respective Git repository.
-
-You must set up a token @strong{before} you can add the first repository.
-See @ref{Token Creation}.
-
-The first time @code{forge-pull} is run in a repository, an entry for that
-repository is added to the database and a new value is added to the
-Git variable @code{remote.<remote>.fetch}, which fetches all pull-requests.
-(@code{+refs/pull/*/head:refs/pullreqs/*} for Github)
-
-@code{forge-pull} then fetches topics and other information using the forge's
-API and pull-request references using Git.
-
-The initial fetch can take a while but most of that is done
-asynchronously.  Storing the information in the database is done
-synchronously though, so there can be a noticeable hang at the end.
-Subsequent fetches are much faster.
-
-Fetching issues from Github is much faster than fetching from other
-forges because making a handful of GraphQL requests is much faster
-than making hundreds of REST requests.
 
 @node Token Creation
 @section Token Creation
@@ -479,6 +450,35 @@ and write access to everything.  The Gitlab API provides more
 fine-grained scopes for read-only access, but when any write access
 at all is required, then it is all or nothing.
 @end itemize
+
+@node Initial Pull
+@section Initial Pull
+
+To start using Forge in a certain repository visit the Magit status
+buffer for that repository and type @code{f y} (@code{forge-pull}).  Alternatively,
+you can use @code{M-x forge-add-repository}, which makes it possible to add a
+forge repository without pulling all topics and even without having to
+clone the respective Git repository.
+
+You must set up a token @strong{before} you can add the first repository.
+See @ref{Token Creation}.
+
+The first time @code{forge-pull} is run in a repository, an entry for that
+repository is added to the database and a new value is added to the
+Git variable @code{remote.<remote>.fetch}, which fetches all pull-requests.
+(@code{+refs/pull/*/head:refs/pullreqs/*} for Github)
+
+@code{forge-pull} then fetches topics and other information using the forge's
+API and pull-request references using Git.
+
+The initial fetch can take a while but most of that is done
+asynchronously.  Storing the information in the database is done
+synchronously though, so there can be a noticeable hang at the end.
+Subsequent fetches are much faster.
+
+Fetching issues from Github is much faster than fetching from other
+forges because making a handful of GraphQL requests is much faster
+than making hundreds of REST requests.
 
 @node Repository Detection
 @section Repository Detection


### PR DESCRIPTION
----

This does a few things:
 - Adds an example for setting the `forge.remote` git config variable
 - Removes the reference to the wizard in the `Initial Pull` section.
 
   Previously, this read:
 
   ```
   When adding the first repository from https://github.com to your local
   database you will be guided through the process of creating the API token
   ```
 - Swaps around the `Initial Pull` and `Token Creation` sections.  There isn't a wizard anymore, so the token must be created first.

#