### PR TITLE
Add browse file support

### DIFF
--- a/lisp/forge-bitbucket.el
+++ b/lisp/forge-bitbucket.el
@@ -35,10 +35,18 @@
    (pullreq-post-url-format   :initform "https://%h/%o/%n/pull-requests/%i#comment-%I")
    (commit-url-format         :initform "https://%h/%o/%n/commits/%r")
    (branch-url-format         :initform "https://%h/%o/%n/branch/%r")
+   (file-url-format           :initform "https://%h/%o/%n/src/%r/%f#lines-%l")
    (remote-url-format         :initform "https://%h/%o/%n/src")
    (create-issue-url-format   :initform "https://%h/%o/%n/issues/new")
    (create-pullreq-url-format :initform "https://%h/%o/%n/pull-requests/new")))
 
 ;;; _
+
+(cl-defmethod forge--file-url ((repo forge-bitbucket-repository) rev file start end)
+  (let* ((start-fragment (number-to-string start))
+         (location-fragment (if end (concat start-fragment ":" (number-to-string end)) start-fragment)))
+    (forge--format repo 'file-url-format
+                   `((?r . ,rev) (?f . ,file) (?l . ,location-fragment)))))
+
 (provide 'forge-bitbucket)
 ;;; forge-bitbucket.el ends here

--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -208,6 +208,19 @@ Prefer a topic over a branch and that over a commit."
                     `((?r . ,(magit-commit-p rev)))))))
 
 ;;;###autoload
+(defun forge-browse-buffer-file ()
+  "Visit the url corresponding to the actual file and location."
+  (interactive
+   (browse-url
+    (let
+        ((rev (magit-get-current-branch))
+         (repo (forge-get-repository 'stub))
+         (file (magit-file-relative-name buffer-file-name))
+         (line-number (line-number-at-pos)))
+      (forge--format repo 'file-url-format
+                     `((?r . ,rev) (?f . ,file) (?l . ,line-number)))))))
+
+;;;###autoload
 (defun forge-copy-url-at-point-as-kill ()
   "Copy the url of the thing at point."
   (interactive)

--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -216,8 +216,9 @@ Prefer a topic over a branch and that over a commit."
         (start (if (use-region-p)
                    (line-number-at-pos (region-beginning))
                  (line-number-at-pos)))
-        (end (when (use-region-p) (line-number-at-pos (region-end)))))
-    (forge--file-url repo rev file start end)))
+        (end (when (use-region-p)
+               (1- (line-number-at-pos (region-end))))))
+    (forge--file-url repo rev file start (when (/= start end) end))))
 
 ;;;###autoload
 (defun forge-buffer-location-as-kill ()

--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -218,7 +218,7 @@ Prefer a topic over a branch and that over a commit."
                  (line-number-at-pos)))
         (end (when (use-region-p)
                (1- (line-number-at-pos (region-end))))))
-    (forge--file-url repo rev file start (when (/= start end) end))))
+    (forge--file-url repo rev file start (when (and end (/= start end)) end))))
 
 ;;;###autoload
 (defun forge-buffer-location-as-kill ()

--- a/lisp/forge-gitea.el
+++ b/lisp/forge-gitea.el
@@ -35,11 +35,19 @@
    (pullreq-post-url-format   :initform "https://%h/%o/%n/pulls/%i#issuecomment-%I")
    (commit-url-format         :initform "https://%h/%o/%n/commit/%r")
    (branch-url-format         :initform "https://%h/%o/%n/commits/branch/%r")
+   (file-url-format           :initform "https://%h/%o/%n/src/branch/%r/%f#%l")
    (remote-url-format         :initform "https://%h/%o/%n")
    (create-issue-url-format   :initform "https://%h/%o/%n/issues/new")
    (create-pullreq-url-format :initform "https://%h/%o/%n/pulls") ; sic
    (pullreq-refspec :initform "+refs/pull/*/head:refs/pullreqs/*")))
 
 ;;; _
+
+(cl-defmethod forge--file-url ((repo forge-gitea-repository) rev file start end)
+  (let* ((start-fragment (concat "L" (number-to-string start)))
+         (location-fragment (if end (concat start-fragment "-L" (number-to-string end)) start-fragment)))
+    (forge--format repo 'file-url-format
+                   `((?r . ,rev) (?f . ,file) (?l . ,location-fragment)))))
+
 (provide 'forge-gitea)
 ;;; forge-gitea.el ends here

--- a/lisp/forge-github.el
+++ b/lisp/forge-github.el
@@ -37,6 +37,7 @@
    (pullreq-post-url-format   :initform "https://%h/%o/%n/pull/%i#issuecomment-%I")
    (commit-url-format         :initform "https://%h/%o/%n/commit/%r")
    (branch-url-format         :initform "https://%h/%o/%n/commits/%r")
+   (file-url-format           :initform "https://%h/%o/%n/blob/%r/%f#L%l")
    (remote-url-format         :initform "https://%h/%o/%n")
    (create-issue-url-format   :initform "https://%h/%o/%n/issues/new")
    (create-pullreq-url-format :initform "https://%h/%o/%n/compare")

--- a/lisp/forge-github.el
+++ b/lisp/forge-github.el
@@ -37,7 +37,7 @@
    (pullreq-post-url-format   :initform "https://%h/%o/%n/pull/%i#issuecomment-%I")
    (commit-url-format         :initform "https://%h/%o/%n/commit/%r")
    (branch-url-format         :initform "https://%h/%o/%n/commits/%r")
-   (file-url-format           :initform "https://%h/%o/%n/blob/%r/%f#L%l")
+   (file-url-format           :initform "https://%h/%o/%n/blob/%r/%f#%l")
    (remote-url-format         :initform "https://%h/%o/%n")
    (create-issue-url-format   :initform "https://%h/%o/%n/issues/new")
    (create-pullreq-url-format :initform "https://%h/%o/%n/compare")
@@ -649,6 +649,13 @@
                       (and (not (equal fork (ghub--username (ghub--host nil))))
                            `((organization . ,fork))))
     (ghub-wait (format "/repos/%s/%s" fork name) nil :auth 'forge)))
+
+
+(cl-defmethod forge--file-url ((repo forge-github-repository) rev file start end)
+  (let* ((start-fragment (concat "L" (number-to-string start)))
+         (location-fragment (if end (concat start-fragment "-L" (number-to-string end)) start-fragment)))
+    (forge--format repo 'file-url-format
+                   `((?r . ,rev) (?f . ,file) (?l . ,location-fragment)))))
 
 ;;; Utilities
 

--- a/lisp/forge-gitlab.el
+++ b/lisp/forge-gitlab.el
@@ -37,6 +37,7 @@
    (pullreq-post-url-format   :initform "https://%h/%o/%n/merge_requests/%i#note_%I")
    (commit-url-format         :initform "https://%h/%o/%n/commit/%r")
    (branch-url-format         :initform "https://%h/%o/%n/commits/%r")
+   (file-url-format           :initform "https://%h/%o/%n/-/blob/%r/%f#L%l")
    (remote-url-format         :initform "https://%h/%o/%n")
    (create-issue-url-format   :initform "https://%h/%o/%n/issues/new")
    (create-pullreq-url-format :initform "https://%h/%o/%n/merge_requests/new")

--- a/lisp/forge-gitlab.el
+++ b/lisp/forge-gitlab.el
@@ -37,11 +37,11 @@
    (pullreq-post-url-format   :initform "https://%h/%o/%n/merge_requests/%i#note_%I")
    (commit-url-format         :initform "https://%h/%o/%n/commit/%r")
    (branch-url-format         :initform "https://%h/%o/%n/commits/%r")
-   (file-url-format           :initform "https://%h/%o/%n/-/blob/%r/%f#L%l")
+   (file-url-format           :initform "https://%h/%o/%n/-/blob/%r/%f#%l")
    (remote-url-format         :initform "https://%h/%o/%n")
    (create-issue-url-format   :initform "https://%h/%o/%n/issues/new")
    (create-pullreq-url-format :initform "https://%h/%o/%n/merge_requests/new")
-   (pullreq-refspec :initform "+refs/merge-requests/*/head:refs/pullreqs/*")))
+   (pullreq-refspec           :initform "+refs/merge-requests/*/head:refs/pullreqs/*")))
 
 ;;; Pull
 ;;;; Repository
@@ -541,6 +541,12 @@
                       :noerror t)
     (ghub-wait (format "/projects/%s%%2F%s" fork name)
                nil :auth 'forge :forge 'gitlab)))
+
+(cl-defmethod forge--file-url ((repo forge-gitlab-repository) rev file start end)
+  (let* ((start-fragment (concat "L" (number-to-string start)))
+         (location-fragment (if end (concat start-fragment "-L" (number-to-string end)) start-fragment)))
+    (forge--format repo 'file-url-format
+                   `((?r . ,rev) (?f . ,file) (?l . ,location-fragment)))))
 
 ;;; Utilities
 

--- a/lisp/forge-gitlab.el
+++ b/lisp/forge-gitlab.el
@@ -544,7 +544,7 @@
 
 (cl-defmethod forge--file-url ((repo forge-gitlab-repository) rev file start end)
   (let* ((start-fragment (concat "L" (number-to-string start)))
-         (location-fragment (if end (concat start-fragment "-L" (number-to-string end)) start-fragment)))
+         (location-fragment (if end (concat start-fragment "-" (number-to-string end)) start-fragment)))
     (forge--format repo 'file-url-format
                    `((?r . ,rev) (?f . ,file) (?l . ,location-fragment)))))
 

--- a/lisp/forge-gogs.el
+++ b/lisp/forge-gogs.el
@@ -34,11 +34,19 @@
    (pullreq-post-url-format   :initform "https://%h/%o/%n/pulls/%i#issuecomment-%I")
    (commit-url-format         :initform "https://%h/%o/%n/commit/%r")
    (branch-url-format         :initform "https://%h/%o/%n/commits/%r")
+   (file-url-format           :initform "https://%h/%o/%n/src/branch/%r/%f#%l")
    (remote-url-format         :initform "https://%h/%o/%n")
    (create-issue-url-format   :initform "https://%h/%o/%n/issues/new")
    (create-pullreq-url-format :initform "https://%h/%o/%n/pulls") ; sic
    (pullreq-refspec :initform "+refs/pull/*/head:refs/pullreqs/*")))
 
 ;;; _
+
+(cl-defmethod forge--file-url ((repo forge-gogs-repository) rev file start end)
+  (let* ((start-fragment (concat "L" (number-to-string start)))
+         (location-fragment (if end (concat start-fragment "-L" (number-to-string end)) start-fragment)))
+    (forge--format repo 'file-url-format
+                   `((?r . ,rev) (?f . ,file) (?l . ,location-fragment)))))
+
 (provide 'forge-gogs)
 ;;; forge-gogs.el ends here

--- a/lisp/forge-repo.el
+++ b/lisp/forge-repo.el
@@ -38,6 +38,7 @@
    (pullreq-post-url-format   :initform nil :allocation :class)
    (commit-url-format         :initform nil :allocation :class)
    (branch-url-format         :initform nil :allocation :class)
+   (file-url-format           :initform nil :allocation :class)
    (remote-url-format         :initform nil :allocation :class)
    (create-issue-url-format   :initform nil :allocation :class)
    (create-pullreq-url-format :initform nil :allocation :class)


### PR DESCRIPTION
This pull-request adds a new feature to forge to be able to open in the browser / kill the URL of the actual file on the specific location for all the supported Git providers.

Adds the following functions:

```elisp
(forge-buffer-location)
```

```elisp
(forge-buffer-location-as-kill)
```

```elisp
(forge-browse-buffer)
```