### PR TITLE
docs/forge Add :ensure t for use-package

### DIFF
--- a/docs/forge.org
+++ b/docs/forge.org
@@ -252,6 +252,7 @@ Or if you use ~use-package~:
 
 #+BEGIN_SRC emacs-lisp
   (use-package forge
+    :ensure t
     :after magit)
 #+END_SRC
 


### PR DESCRIPTION
For someone new to emacs/magit/forge it probably helpful to include
the necessary :ensure t, even if that is not the main point of the
code snippet.
