### PR TITLE
manual: Fix typo creating issues

### DIFF
--- a/docs/forge.org
+++ b/docs/forge.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Forge: (forge).
 #+TEXINFO_DIR_DESC: Access Git Forges from Magit
-#+SUBTITLE: for version 0.1.0 (v0.1.0-371-gf4c95dd0+1)
+#+SUBTITLE: for version 0.1.0 (v0.1.0-372-g315aeb40+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:4 toc:2
@@ -20,7 +20,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 #+TEXINFO: @noindent
-This manual is for Forge version 0.1.0 (v0.1.0-371-gf4c95dd0+1).
+This manual is for Forge version 0.1.0 (v0.1.0-372-g315aeb40+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2018-2021 Jonas Bernoulli <jonas@bernoul.li>
@@ -738,7 +738,7 @@ dedicated buffers:
   This command creates a new pull-request for the current repository.
 
 - Key: ' c i, forge-create-issue
-- Key: C-c C-n [on "Issues" section], forge-create-pullreq
+- Key: C-c C-n [on "Issues" section], forge-create-issue
 
   This command creates a new issue for the current repository.
 

--- a/docs/forge.texi
+++ b/docs/forge.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Forge User and Developer Manual
-@subtitle for version 0.1.0 (v0.1.0-371-gf4c95dd0+1)
+@subtitle for version 0.1.0 (v0.1.0-372-g315aeb40+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -48,7 +48,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 @noindent
-This manual is for Forge version 0.1.0 (v0.1.0-371-gf4c95dd0+1).
+This manual is for Forge version 0.1.0 (v0.1.0-372-g315aeb40+1).
 
 @quotation
 Copyright (C) 2018-2021 Jonas Bernoulli <jonas@@bernoul.li>
@@ -1036,8 +1036,8 @@ This command creates a new pull-request for the current repository.
 @cindex forge-create-issue
 @item @kbd{' c i} @tie{}@tie{}@tie{}@tie{}(@code{forge-create-issue})
 @kindex C-c C-n [on "Issues" section]
-@cindex forge-create-pullreq
-@item @kbd{C-c C-n [on "Issues" section]} @tie{}@tie{}@tie{}@tie{}(@code{forge-create-pullreq})
+@cindex forge-create-issue
+@item @kbd{C-c C-n [on "Issues" section]} @tie{}@tie{}@tie{}@tie{}(@code{forge-create-issue})
 
 This command creates a new issue for the current repository.
 @end table


### PR DESCRIPTION
The "Creating topics" section wrongly claimed that the command called
with C-c C-n in the Issues section was forge-create-pullreq when it's
actually forge-create-issue. Fix the invoked command.