### PR TITLE
Correctly pull GitLab data with forge.omitExpensive

### DIFF
--- a/lisp/forge-gitlab.el
+++ b/lisp/forge-gitlab.el
@@ -51,7 +51,10 @@
                   (dir default-directory)
                   (val nil))
               (lambda (cb &optional v)
-                (when v (if val (push v val) (setq val v)))
+                (when v
+                  (if (consp (car v))
+                      (setq val (append v val))
+                    (push v val)))
                 (let-alist val
                   (cond
                    ((not val)


### PR DESCRIPTION
When `forge.omitExpensive` is set, some expensive fetches are avoided by
adding empty entries for them in a result variable.  However, this broke
handling the result of fetching the repository data: it was added a
level deeper than expected in the remaining code.

Fix this issue by looking at the result data: if the first element is a
cons cell it is the repository data and should be appended, otherwise it
is an additional fetch (issues, pull requests, ...) and should be pushed
to the results variable.