### PR TITLE
Add new option `forge.dontAutoSyncOnSubmit`

### DIFF
--- a/lisp/forge-post.el
+++ b/lisp/forge-post.el
@@ -217,7 +217,8 @@
                           (forge-pullreq-p topic))
                      (oref repo selective-p)))
             (forge--pull-topic repo (oref topic number))
-          (forge-pull))))))
+          (unless (magit-get-boolean "forge.dontAutoSyncOnSubmit")
+            (forge-pull)))))))
 
 (defun forge--post-submit-errorback ()
   (lambda (error &rest _)

--- a/lisp/forge-repo.el
+++ b/lisp/forge-repo.el
@@ -318,7 +318,7 @@ Return the repository identified by HOST, OWNER and NAME."
       (with-current-buffer
           (or buf (current-buffer))
         (unless (magit-get-boolean "forge.dontAutoSyncOnSubmit")
-          (forge-pull)))))
+          (forge-pull))))))
 
 (defvar forge--mode-line-buffer nil)
 

--- a/lisp/forge-repo.el
+++ b/lisp/forge-repo.el
@@ -317,7 +317,8 @@ Return the repository identified by HOST, OWNER and NAME."
     (lambda (&rest _)
       (with-current-buffer
           (or buf (current-buffer))
-        (forge-pull)))))
+        (unless (magit-get-boolean "forge.dontAutoSyncOnSubmit")
+          (forge-pull)))))
 
 (defvar forge--mode-line-buffer nil)
 


### PR DESCRIPTION
This Git configuration option suppresses the automatic `forge-pull` to
update the repo's status after submitting a post or changing a topic. It
trades off responsivness of the UI to subsequent commands for
potentially needing to re-pull and resync the local database manually.

My use-case here is that I'm working with a very active private repo at work with hundreds of open issues and dozens of open pull requests at any given time, and find myself updating (relabeling, closing, reopening) and adding comments to many issues in a short session. Waiting for `forge-pull` to complete every time I update labels, when working with that many issues, is frustratingly slow especially since it locks up the UI.

Note that I'm opening this early to solicit feedback and would be very happy to do something else or close this if there's a better suggested workflow I should adopt.