### PR TITLE
Add yaml dependency and use it for parsing YAML

### DIFF
--- a/default.mk
+++ b/default.mk
@@ -29,6 +29,7 @@ DEPS += markdown-mode
 DEPS += transient/lisp
 DEPS += treepy
 DEPS += with-editor
+DEPS += yaml
 
 VERSION ?= $(shell test -e $(TOP).git && git describe --tags --abbrev=0 | cut -c2-)
 

--- a/forge-pkg.el
+++ b/forge-pkg.el
@@ -8,6 +8,7 @@
     (let-alist      "1.0.6")
     (magit          "3.0.0")
     (markdown-mode  "2.4")
-    (transient      "0.3.3"))
+    (transient      "0.3.3")
+    (yaml           "0.3.3"))
   :homepage "https://github.com/magit/forge"
   :keywords '("git" "tools" "vc"))

--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -26,6 +26,7 @@
 (require 'bug-reference)
 (require 'markdown-mode)
 (require 'parse-time)
+(require 'yaml)
 
 (require 'forge)
 (require 'forge-post)
@@ -767,34 +768,17 @@ Return a value between 0 and 1."
       (forward-line)
       (setq beg (point))
       (when (re-search-forward "^---[\s\t]*$" nil t)
-        (setq end (match-end 0))
-        (push (cons 'head (magit--buffer-string nil end ?\n)) alist)
-        ;; Appending a newline would be correct, but Github does it
-        ;; too, regardless of whether one is there already or not.
-        (push (cons 'body (magit--buffer-string end nil t)) alist)
-        (goto-char beg)
-        (while (re-search-forward "^\\([a-zA-Z]*\\):[\s\t]\\(.+\\)" end t)
-          (push (cons (intern (match-string-no-properties 1))
-                      (let ((v (match-string-no-properties 2)))
-                        ;; This works if the template generator was
-                        ;; used, but yaml allows for other formats.
-                        ;; Do you want to implement a yaml parser?
-                        (cond
-                         ((string-match "^\\([\"']\\)\\1[\s\t]*$" v) nil)
-                         ((string-match "^\\([\"']\\)\\(.+\\)\\1[\s\t]*$" v)
-                          (string-trim (match-string 2 v)))
-                         ((string-match "," v)
-                          (split-string v ",[\s\t]+"))
-                         (t (string-trim v)))))
-                alist))
-        (let-alist alist
-          (setf (alist-get 'prompt alist)
-                (format "[%s] %s" .name .about))
-          (when (and .labels (atom .labels))
-            (setf (alist-get 'labels alist) (list .labels)))
-          (when (and .assignees (atom .assignees))
-            (setf (alist-get 'assignees alist) (list .assignees))))
-        alist))))
+        (setq end (match-beginning 0))
+        (let* ((front-matter (buffer-substring-no-properties beg end))
+               (alist (yaml-parse-string front-matter :object-type 'alist)))
+          (let-alist alist
+            (setf (alist-get 'prompt alist)
+                  (format "[%s] %s" .name .about))
+            (when (and .labels (atom .labels))
+              (setf (alist-get 'labels alist) (list .labels)))
+            (when (and .assignees (atom .assignees))
+              (setf (alist-get 'assignees alist) (list .assignees))))
+          alist)))))
 
 (defun forge--topic-parse-plain ()
   (let (title body)
@@ -817,21 +801,8 @@ Return a value between 0 and 1."
               (forge--topic-parse-yaml-links)))))
 
 (defun forge--topic-parse-yaml-links ()
-  (when (re-search-forward "^contact_links:" nil t)
-    (let (link links)
-      (forward-line)
-      (while (looking-at "^  \\(.\\) \\([^:]*\\):[\s\t]*\\(.*\\)")
-        (let ((next (equal (match-string-no-properties 1) "-"))
-              (key (intern (match-string-no-properties 2)))
-              (val (match-string-no-properties 3)))
-          (when (string-match-p "\\`\".+\"\\'" val)
-            (setq val (substring val 1 -1)))
-          (when (and next link)
-            (push link links)
-            (setq link nil))
-          (setf (alist-get key link) val))
-        (forward-line))
-      (nreverse (mapcar #'nreverse links)))))
+  (let ((alist (yaml-parse-string (buffer-substring-no-properties (point-min) (point-max)) :object-type 'alist :sequence-type 'list)))
+    (alist-get 'contact_links alist)))
 
 ;;; Templates
 

--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -769,16 +769,17 @@ Return a value between 0 and 1."
       (setq beg (point))
       (when (re-search-forward "^---[\s\t]*$" nil t)
         (setq end (match-beginning 0))
-        (let* ((front-matter (buffer-substring-no-properties beg end))
-               (alist (yaml-parse-string front-matter :object-type 'alist)))
-          (let-alist alist
-            (setf (alist-get 'prompt alist)
-                  (format "[%s] %s" .name .about))
-            (when (and .labels (atom .labels))
-              (setf (alist-get 'labels alist) (list .labels)))
-            (when (and .assignees (atom .assignees))
-              (setf (alist-get 'assignees alist) (list .assignees))))
-          alist)))))
+        (setq alist (yaml-parse-string
+                     (buffer-substring-no-properties beg end)
+                     :object-type 'alist))
+        (let-alist alist
+          (setf (alist-get 'prompt alist)
+                (format "[%s] %s" .name .about))
+          (when (and .labels (atom .labels))
+            (setf (alist-get 'labels alist) (list .labels)))
+          (when (and .assignees (atom .assignees))
+            (setf (alist-get 'assignees alist) (list .assignees))))))
+    alist))
 
 (defun forge--topic-parse-plain ()
   (let (title body)
@@ -801,8 +802,12 @@ Return a value between 0 and 1."
               (forge--topic-parse-yaml-links)))))
 
 (defun forge--topic-parse-yaml-links ()
-  (let ((alist (yaml-parse-string (buffer-substring-no-properties (point-min) (point-max)) :object-type 'alist :sequence-type 'list)))
-    (alist-get 'contact_links alist)))
+  (alist-get 'contact_links
+             (yaml-parse-string (buffer-substring-no-properties
+                                 (point-min)
+                                 (point-max))
+                                :object-type 'alist
+                                :sequence-type 'list)))
 
 ;;; Templates
 


### PR DESCRIPTION
This PR adds the yaml dependency located at https://github.com/zkry/yaml.el/ (https://melpa.org/#/yaml). Using a specialized YAML parser for this simplifies the code and makes it more resilient to syntactical variations that may occur. This dependency may also ease the extraction of different metadata later on.