### PR TITLE
Fix small typo in forge.org

### DIFF
--- a/docs/forge.org
+++ b/docs/forge.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Forge: (forge).
 #+TEXINFO_DIR_DESC: Access Git Forges from Magit
-#+SUBTITLE: for version 0.2.1 (v0.2.1-9-gb4fd0666+1)
+#+SUBTITLE: for version 0.2.1 (v0.2.1-10-gcd1ea6f3+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:4 toc:2
@@ -20,7 +20,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 #+TEXINFO: @noindent
-This manual is for Forge version 0.2.1 (v0.2.1-9-gb4fd0666+1).
+This manual is for Forge version 0.2.1 (v0.2.1-10-gcd1ea6f3+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2018-2021 Jonas Bernoulli <jonas@bernoul.li>
@@ -226,7 +226,7 @@ less likely that I will every do it every time I look at it.
 * Getting Started
 ** _ :ignore:
 
-Getting started using Forge should be fairly easy provide you take the
+Getting started using Forge should be fairly easy provided you take the
 time to read the documentation.  First see [[info:ghub#Getting Started]]
 from Ghub's manual.  Ghub is the library that Forge uses to
 communicate with forge APIs.  While Ghub can be used independently of

--- a/docs/forge.texi
+++ b/docs/forge.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Forge User and Developer Manual
-@subtitle for version 0.2.1 (v0.2.1-9-gb4fd0666+1)
+@subtitle for version 0.2.1 (v0.2.1-10-gcd1ea6f3+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -48,7 +48,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 @noindent
-This manual is for Forge version 0.2.1 (v0.2.1-9-gb4fd0666+1).
+This manual is for Forge version 0.2.1 (v0.2.1-10-gcd1ea6f3+1).
 
 @quotation
 Copyright (C) 2018-2021 Jonas Bernoulli <jonas@@bernoul.li>
@@ -376,7 +376,7 @@ log is just one click away from there).
 @node Getting Started
 @chapter Getting Started
 
-Getting started using Forge should be fairly easy provide you take the
+Getting started using Forge should be fairly easy provided you take the
 time to read the documentation.  First see @ref{Getting Started,,,ghub,}
 from Ghub's manual.  Ghub is the library that Forge uses to
 communicate with forge APIs.  While Ghub can be used independently of


### PR DESCRIPTION
Fixed a grammatical error in forge.org documentation.