### PR TITLE
Adapt to emacs-28 bug-reference-bug-regexp contract

### DIFF
--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -899,8 +899,7 @@ modify `bug-reference-bug-regexp' if appropriate."
                            (dolist (f hook)
                              (when (funcall f)
                                (setq bug-reference-bug-regexp
-                                     (format "[^\n]\\(?99:%s\\)"
-                                             bug-reference-bug-regexp))
+                                     (concat "." bug-reference-bug-regexp))
                                (throw 'success t)))))))))
           (setq-local bug-reference-url-format
                       (if (forge--childp repo 'forge-gitlab-repository)


### PR DESCRIPTION
Starting with emacs 28, the first group in `bug-reference-bug-regexp` defines
the bounds of the bug-reference overlay, so prepend just a "." to
`bug-reference-bug-regexp` in order to prevent it from matching at BOL.

With `bug-reference-bug-regexp` values which don't conform to this new
contract, the char before the bug references will be highlighted, too, but
bug-reference.el issues a warning pinpointing what needs to be adapted anyhow.

* lisp/forge-topic.el (forge-bug-reference-setup): Prepend "." to
bug-reference-bug-regexp in order to prevent matching at BOL.