### PR TITLE
docs: Add a FAQ: HTTP Error 502 "Bad gateway"

### DIFF
--- a/docs/forge.org
+++ b/docs/forge.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Forge: (forge).
 #+TEXINFO_DIR_DESC: Access Git Forges from Magit
-#+SUBTITLE: for version 0.2.1 (v0.2.1-18-g70e8246b+1)
+#+SUBTITLE: for version 0.2.1 (v0.2.1-36-g01663d3+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:4 toc:2
@@ -20,7 +20,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 #+TEXINFO: @noindent
-This manual is for Forge version 0.2.1 (v0.2.1-18-g70e8246b+1).
+This manual is for Forge version 0.2.1 (v0.2.1-36-g01663d3+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2018-2021 Jonas Bernoulli <jonas@bernoul.li>
@@ -942,6 +942,11 @@ The following commands are available in buffers used to edit posts:
 
 Yes.  ~M-x forge-add-repository~ offers to add a repository to the
 database without also fetching all pull-requests and issues.
+
+** error in process filter HTTP Error 502 Bad gateway
+
+We don't know why it happens, yet.  See
+https://github.com/magit/ghub/issues/83
 
 * Keystroke Index
 :PROPERTIES:

--- a/docs/forge.texi
+++ b/docs/forge.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Forge User and Developer Manual
-@subtitle for version 0.2.1 (v0.2.1-18-g70e8246b+1)
+@subtitle for version 0.2.1 (v0.2.1-36-g01663d3+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -48,7 +48,7 @@ Forge allows you to work with Git forges, such as Github and Gitlab,
 from the comfort of Magit and the rest of Emacs.
 
 @noindent
-This manual is for Forge version 0.2.1 (v0.2.1-18-g70e8246b+1).
+This manual is for Forge version 0.2.1 (v0.2.1-36-g01663d3+1).
 
 @quotation
 Copyright (C) 2018-2021 Jonas Bernoulli <jonas@@bernoul.li>
@@ -111,6 +111,7 @@ Working with Topics
 FAQ
 
 * Is it possible to create a single pull-request without pulling everything?::
+* error in process filter HTTP Error 502 Bad gateway::
 
 @end detailmenu
 @end menu
@@ -1308,6 +1309,7 @@ under heavy development.
 
 @menu
 * Is it possible to create a single pull-request without pulling everything?::
+* error in process filter HTTP Error 502 Bad gateway::
 @end menu
 
 @node Is it possible to create a single pull-request without pulling everything?
@@ -1315,6 +1317,12 @@ under heavy development.
 
 Yes.  @code{M-x forge-add-repository} offers to add a repository to the
 database without also fetching all pull-requests and issues.
+
+@node error in process filter HTTP Error 502 Bad gateway
+@appendixsec error in process filter HTTP Error 502 Bad gateway
+
+We don't know why it happens, yet.  See
+@uref{https://github.com/magit/ghub/issues/83}
 
 @node Keystroke Index
 @appendix Keystroke Index


### PR DESCRIPTION
Many of us get this 502 Bad gateway error while `forge-pull` (f y).  Add a link to the related discussion.

ps. `ox-texinfo` didn't allow me to use the exact notation:

    HTTP Error: 502, "Bad gateway", "/graphql"

Thus, the FAQ is without punctuation.