### PR TITLE
Add Gnome's gitlab instance to forge-alist

### DIFF
--- a/lisp/forge-core.el
+++ b/lisp/forge-core.el
@@ -61,6 +61,8 @@
      "salsa.debian.org" forge-gitlab-repository)
     ("framagit.org" "framagit.org/api/v4"
      "framagit.org" forge-gitlab-repository)
+    ("gitlab.gnome.org" "gitlab.gnome.org/api/v4"
+     "gitlab.gnome.org" forge-gitlab-repository)
     ;; Forges (API unsupported)
     ("codeberg.org" "codeberg.org/api/v1"
      "codeberg.org" forge-gitea-repository)


### PR DESCRIPTION
This PR adds the Gnome project's GitLab instance to `forge-alist`.