### PR TITLE
docs: Fix link for issue from FAQ

### DIFF
--- a/docs/forge.org
+++ b/docs/forge.org
@@ -1009,7 +1009,7 @@ repeatedly and possibly after a delay to give whatever congestion may
 exist on the other end a chance to clear or to give their caches a
 chance to warm up.
 
-This was also discussed in https://github.com/magit/ghub/issues/20 and
+This was also discussed in https://github.com/magit/forge/issues/20 and
 https://github.com/magit/ghub/issues/83.
 
 * Keystroke Index

--- a/docs/forge.texi
+++ b/docs/forge.texi
@@ -1395,7 +1395,7 @@ repeatedly and possibly after a delay to give whatever congestion may
 exist on the other end a chance to clear or to give their caches a
 chance to warm up.
 
-This was also discussed in @uref{https://github.com/magit/ghub/issues/20} and
+This was also discussed in @uref{https://github.com/magit/forge/issues/20} and
 @uref{https://github.com/magit/ghub/issues/83}.
 
 @node Keystroke Index


### PR DESCRIPTION
This fixes the link to issue #20 in `magit/forge` (and not `magit/ghub`).

Fixs: #428

Signed-off-by: Christophe de Dinechin <christophe@dinechin.org>
