### PR TITLE
WIP - Super initial gitea notification support

### DIFF
--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -164,7 +164,7 @@ If pulling is too slow, then also consider setting the Git variable
   (interactive)
   (let* ((repo  (forge-get-repository 'stub))
          (class (eieio-object-class repo)))
-    (if (eq class 'forge-github-repository)
+    (if (memq class '(forge-github-repository forge-gitea-repository))
         (forge--pull-notifications class (oref repo githost))
       (user-error "Fetching notifications not supported for forge %S"
                   (oref repo forge)))))

--- a/lisp/forge-gitea.el
+++ b/lisp/forge-gitea.el
@@ -43,6 +43,142 @@
    (create-pullreq-url-format :initform "https://%h/%o/%n/pulls") ; sic
    (pullreq-refspec :initform "+refs/pull/*/head:refs/pullreqs/*")))
 
+
+;;;; Notifications
+
+(cl-defmethod forge--pull-notifications
+  ((_class (subclass forge-gitea-repository)) githost &optional callback)
+  (let ((spec (assoc githost forge-alist)))
+    (unless spec
+      (error "No entry for %S in forge-alist" githost))
+    (forge--msg nil t nil "Pulling notifications")
+    (pcase-let*
+        ((`(,_ ,apihost ,forge ,_) spec)
+         (notifs (-keep (lambda (data)
+                          (forge--gtea-massage-notification
+                           data forge githost))
+                        (forge--gtea-get nil "/notifications"
+                          '((all . "true"))
+                          :host apihost :unpaginate t))))
+      (forge--msg nil t nil "Storing notifications")
+      (emacsql-with-transaction (forge-db)
+        (forge-sql [:delete-from notification
+                                 :where (= forge $s1)] forge)
+        (dolist (obj notifs)
+          (closql-insert (forge-db) obj)
+          (forge--zap-repository-cache (forge-get-repository obj))))))
+  (when callback
+    (funcall callback)))
+
+
+(defun forge--gtea-massage-notification (data forge githost)
+  (let-alist data
+    (let* ((type (intern (downcase .subject.type)))
+           (type (if (eq type 'pull) 'pullreq type)))
+      (and (memq type '(pullreq issue))
+           (let* ((number (and (string-match "[0-9]*\\'" .subject.url)
+                               (string-to-number (match-string 0 .subject.url))))
+                  (repo   (forge-get-repository
+                           (list githost
+                                 .repository.owner.login
+                                 .repository.name)
+                           nil 'create))
+                  (repoid (oref repo id))
+                  (owner  (oref repo owner))
+                  (name   (oref repo name))
+                  (id     (forge--object-id repoid .id)))
+             (forge-notification
+              :id           id
+              :thread-id    .id
+              :repository   repoid
+              :forge        forge
+              :unread-p     .unread
+              :last-read    .last_read_at
+              :updated      .updated_at
+              :title        .subject.title
+              :type         type
+              :topic        number
+              :url          .subject.url))))))
+
+;;; Utilities
+
+(cl-defun forge--gtea-get (obj resource
+                               &optional params
+                               &key query payload headers
+                               silent unpaginate noerror reader
+                               host
+                               callback errorback)
+  (declare (indent defun))
+  (gtea-get (if obj (forge--format-resource obj resource) resource)
+            params
+            :host (or host (oref (forge-get-repository obj) apihost))
+            :auth 'forge
+            :query query :payload payload :headers headers
+            :silent silent :unpaginate unpaginate
+            :noerror noerror :reader reader
+            :callback callback :errorback errorback))
+
+(cl-defun forge--gtea-put (obj resource
+                               &optional params
+                               &key query payload headers
+                               silent unpaginate noerror reader
+                               host
+                               callback errorback)
+  (declare (indent defun))
+  (gtea-put (if obj (forge--format-resource obj resource) resource)
+            params
+            :host (or host (oref (forge-get-repository obj) apihost))
+            :auth 'forge
+            :query query :payload payload :headers headers
+            :silent silent :unpaginate unpaginate
+            :noerror noerror :reader reader
+            :callback callback :errorback errorback))
+
+(cl-defun forge--gtea-post (obj resource
+                                &optional params
+                                &key query payload headers
+                                silent unpaginate noerror reader
+                                host callback errorback)
+  (declare (indent defun))
+  (gtea-post (forge--format-resource obj resource)
+             params
+             :host (or host (oref (forge-get-repository obj) apihost))
+             :auth 'forge
+             :query query :payload payload :headers headers
+             :silent silent :unpaginate unpaginate
+             :noerror noerror :reader reader
+             :callback callback :errorback errorback))
+
+(cl-defun forge--gtea-patch (obj resource
+                                 &optional params
+                                 &key query payload headers
+                                 silent unpaginate noerror reader
+                                 host callback errorback)
+  (declare (indent defun))
+  (gtea-patch (forge--format-resource obj resource)
+              params
+              :host (or host (oref (forge-get-repository obj) apihost))
+              :auth 'forge
+              :query query :payload payload :headers headers
+              :silent silent :unpaginate unpaginate
+              :noerror noerror :reader reader
+              :callback callback :errorback errorback))
+
+(cl-defun forge--gtea-delete (obj resource
+                                  &optional params
+                                  &key query payload headers
+                                  silent unpaginate noerror reader
+                                  host callback errorback)
+  (declare (indent defun))
+  (gtea-delete (forge--format-resource obj resource)
+               params
+               :host (or host (oref (forge-get-repository obj) apihost))
+               :auth 'forge
+               :query query :payload payload :headers headers
+               :silent silent :unpaginate unpaginate
+               :noerror noerror :reader reader
+               :callback callback :errorback errorback))
+
 ;;; _
 (provide 'forge-gitea)
 ;;; forge-gitea.el ends here


### PR DESCRIPTION
Hey,

I was looking to use forge for gitea but there doesn't seem to be any support for, well, anything at all.

I tried my best for the past 2.5 hours and came up with this. It successfully lists notifications. It's mostly copy paste from the github version and it was quite challenging because I'd never seen these generics or eieio stuff in elisp before.

So I mostly wanted to start a discourse here to discuss the current state of gitea support.

Is anyone currently working on this? This would be a pretty big thing for me to try and tackle so I'd love it if someone was.

If no-one is working on it, I'd definitely need some serious help :P. I'm a master of rebasing local changes so please feel free to simply throw some commits on this branch to show me how it's done. I'd really appreciate that.


The manual says gitea is the next forge that will supported but the manual also has a bunch of wrong keybindings so I'm not sure if it's up to date (that was fun thinking my install was wrong because there was no "f y" option. Or is my install actually broken? Should I see an "f y" option?).

P.S. I've never actually used forge (other than viewing a half broken gitea notification page). I should probably try it out before committing to this...