### PR TITLE
Fix forge-pull-topic can not pull topic

### DIFF
--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -180,7 +180,7 @@ If pulling is too slow, then also consider setting the Git variable
   "Pull the API data for the current topic.
 If there is no current topic or with a prefix argument read a
 TOPIC to pull instead."
-  (interactive (list (forge-read-topic "Pull topic" nil t)))
+  (interactive (list (forge-get-topic (forge-read-topic "Pull topic" nil t))))
   (let ((repo (forge-get-repository t)))
     (when (numberp topic)
       (setq topic (forge-issue :repository (oref repo id)


### PR DESCRIPTION
It is necessary to call `forge-get-topic` to get the topic.