### PR TITLE
Only enable bug-reference-mode when Forge repository data is available 

### DIFF
--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -944,12 +944,12 @@ modify `bug-reference-bug-regexp' if appropriate."
           (setq-local bug-reference-bug-regexp
                       (if (forge--childp repo 'forge-gitlab-repository)
                           "\\(?3:[!#]\\)\\(?2:[0-9]+\\)"
-                        "#\\(?2:[0-9]+\\)"))))
-      (if (derived-mode-p 'prog-mode)
-          (bug-reference-prog-mode 1)
-        (bug-reference-mode 1))
-      (add-hook 'completion-at-point-functions
-                'forge-topic-completion-at-point nil t))))
+                        "#\\(?2:[0-9]+\\)")))
+        (if (derived-mode-p 'prog-mode)
+            (bug-reference-prog-mode 1)
+          (bug-reference-mode 1))
+        (add-hook 'completion-at-point-functions
+                  'forge-topic-completion-at-point nil t)))))
 
 (when (and (not noninteractive) forge--sqlite-available-p)
   (dolist (hook forge-bug-reference-hooks)


### PR DESCRIPTION
This PR changes `forge-bug-reference-setup` to only enable `bug-reference-mode` or `bug-reference-prog-mode` when Forge repository data is available.

According to the [function doc-string](https://github.com/magit/forge/blob/9c3b53cdf6c0aae18455a8b9f573846c43ac9df1/lisp/forge-topic.el#L912), this is already the expected behavior, and the current behavior of always enabling `bug-reference-mode` or `bug-reference-prog-mode` is a bug.