### PR TITLE
Reformat transient menu items for consistency

### DIFF
--- a/lisp/forge.el
+++ b/lisp/forge.el
@@ -116,9 +116,9 @@ is loaded, then `magit-mode-map' ends up being modified anyway.")
     '("n" "pull-request worktree" forge-checkout-worktree))
 
   (transient-append-suffix 'magit-status-jump "w"
-    '("Np" "pull-requests" forge-jump-to-pullreqs))
+    '("Np" "Pull requests" forge-jump-to-pullreqs))
   (transient-append-suffix 'magit-status-jump "Np"
-    '("Ni" "issues" forge-jump-to-issues))
+    '("Ni" "Issues" forge-jump-to-issues))
 
   (transient-append-suffix 'magit-merge "a"
     '(7 "M" "Merge using API" forge-merge)))


### PR DESCRIPTION
Just a cosmetic change to make the `magit-status-jump` transient look more consistent and elegant (capitalised and using space as word separator).

Before:

![image](https://user-images.githubusercontent.com/131893/147560662-74cca504-364f-4401-bc77-3c5a2b81554d.png)

After:

![image](https://user-images.githubusercontent.com/131893/147561105-e611bb74-1b8d-442b-9b5e-bb8df952c198.png)

The patch makes the displayed options consistent as well with the titles of the sections in the Magit status buffer:

![image](https://user-images.githubusercontent.com/131893/147560957-dcaa0719-b240-4ab5-bef2-9e016d981d85.png)


