### PR TITLE
Toggle visibility of assigned/authored pullreqs/issues sections

### DIFF
--- a/lisp/forge-issue.el
+++ b/lisp/forge-issue.el
@@ -176,11 +176,12 @@ Also see option `forge-topic-list-limit'."
 
 (defun forge-insert-assigned-issues ()
   "Insert a list of open issues that are assigned to you."
-  (when-let ((repo (forge-get-repository nil)))
-    (unless (oref repo sparse-p)
-      (forge-insert-topics "Assigned issues"
-                           (forge--ls-assigned-issues repo)
-                           (forge--topic-type-prefix repo 'issue)))))
+  (when forge-display-in-status-buffer
+    (when-let ((repo (forge-get-repository nil)))
+      (unless (oref repo sparse-p)
+        (forge-insert-topics "Assigned issues"
+                             (forge--ls-assigned-issues repo)
+                             (forge--topic-type-prefix repo 'issue))))))
 
 (defun forge--ls-assigned-issues (repo)
   (mapcar (lambda (row)
@@ -199,11 +200,12 @@ Also see option `forge-topic-list-limit'."
 
 (defun forge-insert-authored-issues ()
   "Insert a list of open issues that are authored to you."
-  (when-let ((repo (forge-get-repository nil)))
-    (unless (oref repo sparse-p)
-      (forge-insert-topics "Authored issues"
-                           (forge--ls-authored-issues repo)
-                           (forge--topic-type-prefix repo 'issue)))))
+  (when forge-display-in-status-buffer
+    (when-let ((repo (forge-get-repository nil)))
+      (unless (oref repo sparse-p)
+        (forge-insert-topics "Authored issues"
+                             (forge--ls-authored-issues repo)
+                             (forge--topic-type-prefix repo 'issue))))))
 
 (defun forge--ls-authored-issues (repo)
   (mapcar (lambda (row)

--- a/lisp/forge-pullreq.el
+++ b/lisp/forge-pullreq.el
@@ -293,11 +293,12 @@ Also see option `forge-topic-list-limit'."
 
 (defun forge-insert-assigned-pullreqs ()
   "Insert a list of open pull-requests that are assigned to you."
-  (when-let ((repo (forge-get-repository nil)))
-    (unless (oref repo sparse-p)
-      (forge-insert-topics "Assigned pull requests"
-                           (forge--ls-assigned-pullreqs repo)
-                           (forge--topic-type-prefix repo 'pullreq)))))
+  (when forge-display-in-status-buffer
+    (when-let ((repo (forge-get-repository nil)))
+      (unless (oref repo sparse-p)
+        (forge-insert-topics "Assigned pull requests"
+                             (forge--ls-assigned-pullreqs repo)
+                             (forge--topic-type-prefix repo 'pullreq))))))
 
 (defun forge--ls-assigned-pullreqs (repo)
   (mapcar (lambda (row)
@@ -340,11 +341,12 @@ Also see option `forge-topic-list-limit'."
 
 (defun forge-insert-authored-pullreqs ()
   "Insert a list of open pullreqs that are authored to you."
-  (when-let ((repo (forge-get-repository nil)))
-    (unless (oref repo sparse-p)
-      (forge-insert-topics "Authored pullreqs"
-                           (forge--ls-authored-pullreqs repo)
-                           (forge--topic-type-prefix repo 'pullreq)))))
+  (when forge-display-in-status-buffer
+    (when-let ((repo (forge-get-repository nil)))
+      (unless (oref repo sparse-p)
+        (forge-insert-topics "Authored pullreqs"
+                             (forge--ls-authored-pullreqs repo)
+                             (forge--topic-type-prefix repo 'pullreq))))))
 
 (defun forge--ls-authored-pullreqs (repo)
   (mapcar (lambda (row)


### PR DESCRIPTION
I added minor fixes to hide/show not only `Pull requests` and `Issues` sections but also `Assigned pull requests`, `Assigned pull issues`, `Authored pull requests` and `Authored pull issues` sections by pressing `n-t-t` (hide all topics / display topics).