### PR TITLE
Bind Nbr to forge-browse-remote

### DIFF
--- a/docs/forge.org
+++ b/docs/forge.org
@@ -632,6 +632,7 @@ on a commit or branch section.
 
 - Key: C-c C-w (forge-browse-TYPE) ::
 - Key: C-c C-w (forge-browse-dwim) ::
+- Key: N b r (forge-browse-remote) ::
 - Key: N b I (forge-browse-issues) ::
 - Key: N b P (forge-browse-pullreqs) ::
 - Key: N b t (forge-browse-topic) ::

--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -91,7 +91,8 @@ Takes the pull-request as only argument and must return a directory."
     ("b P" "pull-requests" forge-browse-pullreqs)
     ("b t" "topic"         forge-browse-topic)
     ("b i" "issue"         forge-browse-issue)
-    ("b p" "pull-request"  forge-browse-pullreq)]]
+    ("b p" "pull-request"  forge-browse-pullreq)
+    ("b r" "remote"        forge-browse-remote)]]
   [["Configure"
     ("a  " "add repository to database" forge-add-repository)
     ("r  " "forge.remote"  forge-forge.remote)


### PR DESCRIPTION
I was missing a quick binding to open the repo on Github (was used to Magithub's HH binding).