### PR TITLE
Correct key name

### DIFF
--- a/lisp/forge-gitlab.el
+++ b/lisp/forge-gitlab.el
@@ -274,7 +274,7 @@
   (let-alist (car cur)
     (forge--glab-get repo (format "/projects/%s" .target_project_id) nil
       :errorback (lambda (_err _headers _status _req)
-                   (setf (alist-get 'source_project (car cur)) nil)
+                   (setf (alist-get 'target_project (car cur)) nil)
                    (funcall cb cb))
       :callback (lambda (value _headers _status _req)
                   (setf (alist-get 'target_project (car cur)) value)


### PR DESCRIPTION
This function is meant to set to nil the target project in case of an error bringing the information about the project itself, not the source project.