### PR TITLE
Visit the issue/pullreq at point in short link notation

### DIFF
--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -343,15 +343,19 @@ read a topic to visit instead."
 (defun forge-visit-pullreq (pullreq)
   "View the current pull-request in a separate buffer.
 If there is no current pull-request or with a prefix argument
-read a PULLREQ to visit instead."
+read a PULLREQ to visit instead. If point is looking at a pullreq
+reference with Gitlab/Github notation try to visit the pullreq
+with that number."
   (interactive (list (forge-read-pullreq "View pull-request" t)))
   (forge-visit (forge-get-pullreq pullreq)))
 
 ;;;###autoload
 (defun forge-visit-issue (issue)
   "Visit the current issue in a separate buffer.
-If there is no current issue or with a prefix argument
-read an ISSUE to visit instead."
+If there is no current issue or with a prefix argument read an
+ISSUE to visit instead. If point is looking at an issue reference
+with Gitlab/Github notation try to visit the issue with that
+number."
   (interactive (list (forge-read-issue "View issue" t)))
   (forge-visit (forge-get-issue issue)))
 

--- a/lisp/forge-issue.el
+++ b/lisp/forge-issue.el
@@ -128,6 +128,9 @@
 (cl-defmethod forge-get-url ((issue forge-issue))
   (forge--format issue 'issue-url-format))
 
+(defun forge--issue-by-forge-short-link-at-point ()
+  (forge--topic-by-forge-short-link-at-point '("#") #'forge-get-issue))
+
 ;;; Sections
 
 (defun forge-current-issue ()
@@ -146,7 +149,8 @@
         (cond ((forge-issue-p post)
                post)
               ((forge-issue-post-p post)
-               (forge-get-issue post))))))
+               (forge-get-issue post))))
+      (forge--issue-by-forge-short-link-at-point)))
 
 (defvar forge-issues-section-map
   (let ((map (make-sparse-keymap)))

--- a/lisp/forge-post.el
+++ b/lisp/forge-post.el
@@ -80,7 +80,9 @@
                  (n (magit-get "branch" branch "pullRequest")))
         (forge-get-pullreq (string-to-number n)))
       (and-let* ((rev (magit-commit-at-point)))
-        (forge--pullreq-from-rev rev))))
+        (forge--pullreq-from-rev rev))
+      (forge--issue-by-forge-short-link-at-point)
+      (forge--pullreq-by-forge-short-link-at-point)))
 
 (defun forge-current-topic ()
   (or (forge-topic-at-point)

--- a/lisp/forge-pullreq.el
+++ b/lisp/forge-pullreq.el
@@ -221,6 +221,9 @@ yourself, in which case you probably should not reset either.
 (cl-defmethod forge-get-url ((pullreq forge-pullreq))
   (forge--format pullreq 'pullreq-url-format))
 
+(defun forge--pullreq-by-forge-short-link-at-point ()
+  (forge--topic-by-forge-short-link-at-point '("#" "!") #'forge-get-pullreq))
+
 ;;; Sections
 
 (defun forge-current-pullreq ()
@@ -239,7 +242,8 @@ yourself, in which case you probably should not reset either.
         (cond ((forge-pullreq-p post)
                post)
               ((forge-pullreq-post-p post)
-               (forge-get-pullreq post))))))
+               (forge-get-pullreq post))))
+      (forge--pullreq-by-forge-short-link-at-point)))
 
 (defvar forge-pullreqs-section-map
   (let ((map (make-sparse-keymap)))

--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -358,6 +358,18 @@ identifier."
      (format-time-string "%s" (parse-iso8601-time-string (oref topic created)))
      t)))
 
+(defun forge--topic-by-forge-short-link-at-point (known-prefixes finder)
+  "Finds a topic by forge-dependant short link around point.
+The topic number is expected to be a number prefixed by any of
+the elements in KNOWN-PREFIXES. If a reference is found, FINDER
+is called and a topic object is returned if available."
+  (and-let* ((number (number-at-point))
+             (prefix (buffer-substring-no-properties
+                      (- (match-beginning 0) 1)
+                      (match-beginning 0))))
+    (and (member prefix known-prefixes)
+         (funcall finder number))))
+
 ;;; Mode
 
 (defvar forge-topic-mode-map


### PR DESCRIPTION
I find it useful to quickly jump to an issue when for instance reviewing a pull request. Let's say that the pull request description reads as follows:

``` 1c-enterprise
Fix a bug.

Closes #43
```

Placing the point in between `4` and `3` and running `M-x forge-visit-issue` directly visits the issue after this patch, instead of prompting for which issue to visit. The matching could be more sophisticated and only react to integers at point preceded by `#`.

Maybe this could be integrated into `forge-issue-at-point` instead so the discovery would be done by `forge-current-issue` so no modifications to `forge-read-issue` would be needed.

The same idea could be applied to `forge-read-pullreq`, I imagine. Happy to contribute a patch as part of the same pull request.

Haven't check if the manual needs updating. I'll gladly do so if the change request goes forward.