### PR TITLE
Fix `:initform` form for sqlite-builtin and sqlite-module backends

### DIFF
--- a/lisp/forge-db.el
+++ b/lisp/forge-db.el
@@ -93,12 +93,12 @@ to be used like this.  See https://nullprogram.com/blog/2014/02/06/."
    (require (quote emacsql-sqlite-builtin))
    (with-no-warnings
      (defclass forge-database (emacsql-sqlite-builtin-connection closql-database)
-       ((object-class :initform 'epkg-package)))))
+       ((object-class :initform 'forge-repository)))))
   (sqlite-module
    (require (quote emacsql-sqlite-module))
    (with-no-warnings
      (defclass forge-database (emacsql-sqlite-module-connection closql-database)
-       ((object-class :initform 'epkg-package)))))
+       ((object-class :initform 'forge-repository)))))
   (libsqlite3
    (require (quote emacsql-libsqlite3))
    (with-no-warnings


### PR DESCRIPTION
ab637b7 accidentally set `epkg-package` as :initform to the sqlite-builtin and sqlite-module backends.
