### PR TITLE
Add link to autofill GitHub token creation form

### DIFF
--- a/docs/forge.org
+++ b/docs/forge.org
@@ -275,6 +275,10 @@ around reading the documentation and doing this manually I am afraid.
   More information about these and other scopes can be found at
   https://docs.github.com/en/developers/apps/scopes-for-oauth-apps.
 
+  Visiting this link will autopopulate the token creation form with
+  the necessary scopes:
+  https://github.com/settings/tokens/new?scopes=repo,user,read:org&description=magit-forge
+
 - For Gitlab instances ~api~ is the only required scope.  It gives read
   and write access to everything.  The Gitlab API provides more
   fine-grained scopes for read-only access, but when any write access


### PR DESCRIPTION
The GitHub token creation form can be autofilled with scope
selections:
https://github.com/settings/tokens/new?scopes=repo,user,read:org&description=magit-forge
.

It's a bit easier to be able to generate this token with a direct link from the manual.

PS: perhaps this link could be used for automating forge setup?