### PR TITLE
customizable heading/body in new pull requests

### DIFF
--- a/lisp/forge-post.el
+++ b/lisp/forge-post.el
@@ -145,12 +145,10 @@
 (defvar-local forge--pre-post-buffer nil)
 (defvar-local forge--buffer-draft-p nil)
 
-(defun forge-insert-post-buffer-pull-request-heading (source target)
-  (ignore source target)
+(defun forge-insert-post-buffer-pull-request-heading (&optional source target)
   (insert "# "))
 
-(defun forge-insert-post-buffer-pull-request-body (source target)
-  (ignore target)
+(defun forge-insert-post-buffer-pull-request-body (&optional source target)
   (magit-rev-insert-format "%B" source))
 
 (defun forge--prepare-post-buffer (filename &optional header source target)
@@ -194,7 +192,9 @@
                   (insert "title: \n")
                   (backward-char))))
              (t
-              (funcall forge-insert-post-buffer-pull-request-heading-fn source target)
+              (if (and source target)
+                  (funcall forge-insert-post-buffer-pull-request-heading-fn source target)
+                (forge-insert-post-buffer-pull-request-heading))
               (let ((single
                      (and source
                           (= (car (magit-rev-diff-count source target)) 1))))


### PR DESCRIPTION
Hello,

first let me say thank you to the maintainers for your excellent work with magit and forge. I've been enjoying both modes immensely.

I wanted to provide a customizable way to adjust the template for new pull requests. As I mostly use Gitlab, I like to use this as a starting point

```
# Merge <source-branch> into <target-branch>

<commit-message>
```

I refactored `forge--prepare-post-buffer` to use two customizable variables setting the functions for adjusting the headline and the body of the PR template. While the default behavior remains as-is, customizing these variables allows to flexibly set the template as e.g. in

```
(defun my-insert-post-buffer-mr-heading (source target)
  (cl-flet ((replace-regex
	     (x)
	     (replace-regexp-in-string "[a-z]+/" "" x)))
    (insert
     (format "# merge %s into %s" (replace-regex source)
	     (replace-regex target))
     "\n\n" )))
```

Admittedly not the prettiest implementation as I don't have a lot of elisp experience, so I'm open for improvements and alternatives if this is at all interesting to you. 