### PR TITLE
Make forge--buffer-draft-p public

### DIFF
--- a/lisp/forge-github.el
+++ b/lisp/forge-github.el
@@ -512,9 +512,9 @@
 
 (cl-defmethod forge--submit-create-pullreq ((_ forge-github-repository) repo)
   (let-alist (forge--topic-parse-buffer)
-    (when (and .yaml (local-variable-p 'forge--buffer-draft-p))
+    (when (and .yaml (local-variable-p 'forge-buffer-draft-p))
       (user-error "Cannot use yaml frontmatter and set `%s' at the same time"
-                  'forge--buffer-draft-p))
+                  'forge-buffer-draft-p))
     (pcase-let* ((`(,base-remote . ,base-branch)
                   (magit-split-branch-name forge--buffer-base-branch))
                  (`(,head-remote . ,head-branch)
@@ -531,8 +531,8 @@
                         head-branch
                       (concat (oref head-repo owner) ":"
                               head-branch)))
-          (draft . ,(if (local-variable-p 'forge--buffer-draft-p)
-                        forge--buffer-draft-p
+          (draft . ,(if (local-variable-p 'forge-buffer-draft-p)
+                        forge-buffer-draft-p
                       .draft))
           (maintainer_can_modify . t))
         :callback  (forge--post-submit-callback)

--- a/lisp/forge-gitlab.el
+++ b/lisp/forge-gitlab.el
@@ -442,8 +442,8 @@
                   (magit-split-branch-name forge--buffer-head-branch))
                  (head-repo (forge-get-repository 'stub head-remote)))
       (forge--glab-post head-repo "/projects/:project/merge_requests"
-        `((title . ,(if (if (local-variable-p 'forge--buffer-draft-p)
-                            forge--buffer-draft-p
+        `((title . ,(if (if (local-variable-p 'forge-buffer-draft-p)
+                            forge-buffer-draft-p
                           .draft)
                         (concat "Draft: " .title)
                       .title))

--- a/lisp/forge-post.el
+++ b/lisp/forge-post.el
@@ -38,6 +38,15 @@
   :options '(visual-line-mode
              turn-on-flyspell))
 
+(defcustom forge-buffer-draft-p nil
+  "Whether new pull-requests start out as drafts by default.
+
+The buffer-local value is use to keep track of the draft status
+of the current pull-request."
+  :package-version '(forge . "0.4.0")
+  :group 'forge
+  :type 'boolean)
+
 ;;; Class
 
 (defclass forge-post (forge-object) () :abstract t)
@@ -129,7 +138,7 @@
 (defvar-local forge--submit-post-function nil)
 (defvar-local forge--cancel-post-function nil)
 (defvar-local forge--pre-post-buffer nil)
-(defvar-local forge--buffer-draft-p nil)
+(make-variable-buffer-local 'forge-buffer-draft-p)
 
 (defun forge--prepare-post-buffer (filename &optional header source target)
   (let ((file (magit-git-dir
@@ -249,8 +258,8 @@
 (transient-define-infix forge-post-toggle-draft ()
   "Toggle whether the pull-request being created is a draft."
   :class 'transient-lisp-variable
-  :variable 'forge--buffer-draft-p
-  :reader (lambda (&rest _) (not forge--buffer-draft-p))
+  :variable 'forge-buffer-draft-p
+  :reader (lambda (&rest _) (not forge-buffer-draft-p))
   :if (lambda () (equal (file-name-nondirectory buffer-file-name) "new-pullreq")))
 
 ;;; Notes


### PR DESCRIPTION
Closes #516.

-------

This PR makes `forge--buffer-draft-p` public by transforming the
`defvar` into a `defcustom` and replacing the double dash with a
single one.

There are 3 occurrences of `(local-variable-p 'forge-buffer-draft-p)`
that I left intact (beyond transforming the double dash) as I'm not
sure the exact purpose they serve. I can delete these expressions if
you want me to.

I didn't update the manual as I wasn't sure where to put the
information and the other `defcustom` of `forge-post.el` isn't
discussed there. Please tell me what is the most appropriate place if
you want me to write something and I will happily do it.