### PR TITLE
Improve error handling

### DIFF
--- a/lisp/forge-db.el
+++ b/lisp/forge-db.el
@@ -90,10 +90,6 @@ by the `sqlite3' package.  You need to install thef
        ((object-class :initform 'forge-repository))))))
 
 (defconst forge--db-version 9)
-(defconst forge--sqlite-available-p
-  (with-demoted-errors "Forge initialization: %S"
-    (emacsql-sqlite-ensure-binary)
-    t))
 
 (defvar forge--db-connection nil
   "The EmacSQL database connection.")

--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -986,7 +986,7 @@ modify `bug-reference-bug-regexp' if appropriate."
         (add-hook 'completion-at-point-functions
                   #'forge-topic-completion-at-point nil t)))))
 
-(when (and (not noninteractive) forge--sqlite-available-p)
+(unless noninteractive
   (dolist (hook forge-bug-reference-hooks)
     (add-hook hook #'forge-bug-reference-setup)))
 

--- a/lisp/forge.el
+++ b/lisp/forge.el
@@ -66,7 +66,7 @@
 If you want to disable this, then you must set this to nil before
 `forge' is loaded.")
 
-(when (and forge-add-default-sections forge--sqlite-available-p)
+(when forge-add-default-sections
   (magit-add-section-hook 'magit-status-sections-hook #'forge-insert-pullreqs nil t)
   (magit-add-section-hook 'magit-status-sections-hook #'forge-insert-issues   nil t))
 


### PR DESCRIPTION
This PR aims to improve on the fixes introduced in [8ab946](https://github.com/magit/forge/commit/8ab946a5eb1e8de8e54e02f21e65dbd1b97ceff3).

The main idea is that most entry points to Forge call `forge-get-repository` early on, so error handling can be improved by adding a check for whether the database can be accessed to that function. Personally, I think this is a quite nice solution, but others might disagree. Also, I am not completely sure I have understood the purpose of the `demand` argument entirely, so my implementation might be subtly broken.

The new error handling also allows us to remove the `forge--sqlite-available-p` checks. This is desirable because they can cause Forge to be deactivated when a SQLite executable isn't present, even with backends like `sqlite-builtin` that don't require a SQLite executable.