### PR TITLE
Handle saving max topics

### DIFF
--- a/docs/forge.org
+++ b/docs/forge.org
@@ -68,6 +68,11 @@ Forge's support for Github can be considered the "reference
   back to use the REST API in many cases because the former is still
   rather incomplete.
 
+- The Github GraphQL API has a hard-coded timeout on queries. The only solution
+  is to reduce the number of entities we query at once, which can be done by
+  adjusting either the ~forge.graphqlItemLimit~ git variable or the field "GQL
+  entity limit" in a status buffer.
+
 - Forge depends on the ~updated_at~ field being updated when
   appropriate.  For Github pull-requests at least, that is not always
   done.

--- a/docs/forge.texi
+++ b/docs/forge.texi
@@ -165,6 +165,12 @@ back to use the REST API in many cases because the former is still
 rather incomplete.
 
 @item
+The Github GraphQL API has a hard-coded timeout on queries. The only solution
+is to reduce the number of entities we query at once, which can be done by
+adjusting either the @code{forge.graphqlItemLimit} git variable or the field "GQL
+entity limit" in a status buffer.
+
+@item
 Forge depends on the @code{updated_at} field being updated when
 appropriate.  For Github pull-requests at least, that is not always
 done.

--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -96,7 +96,9 @@ Takes the pull-request as only argument and must return a directory."
     ("a  " "add repository to database" forge-add-repository)
     ("r  " "forge.remote"  forge-forge.remote)
     ("t t" forge-toggle-display-in-status-buffer)
-    ("t c" forge-toggle-closed-visibility)]])
+    ("t c" forge-toggle-closed-visibility)
+    ("t l" "GQL entity limit" forge-forge.graphqlItemLimit
+     :if (lambda () (forge-github-repository-p (forge-get-repository nil)))) ]])
 
 ;;; Pull
 
@@ -933,6 +935,12 @@ This only affect the current status buffer."
       (setq forge-topic-list-limit (cons forge-topic-list-limit 5))
     (setcdr forge-topic-list-limit (* -1 (cdr forge-topic-list-limit))))
   (magit-refresh))
+
+(transient-define-infix forge-forge.graphqlItemLimit ()
+  "Change the maximum number of GraphQL entities to pull at once."
+  :class 'magit--git-variable
+  :variable "forge.graphqlItemLimit"
+  :reader #'read-string)
 
 ;;;###autoload
 (defun forge-add-pullreq-refspec ()

--- a/lisp/forge-github.el
+++ b/lisp/forge-github.el
@@ -51,7 +51,10 @@
                            &optional callback)
   (let ((buf (current-buffer))
         (dir default-directory)
-        (selective-p (oref repo selective-p)))
+        (selective-p (oref repo selective-p))
+        (ghub-graphql-items-per-request
+         (string-to-number
+          (or (magit-get "forge.graphqlItemLimit") "100"))))
     (ghub-fetch-repository
      (oref repo owner)
      (oref repo name)


### PR DESCRIPTION
Allows configuration of the forge.max-topics git option for large Github repositories

Depends on https://github.com/magit/ghub/pull/158