### PR TITLE
Prevent post heading face from clobbering author & date faces

### DIFF
--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -455,8 +455,9 @@ is called and a topic object is returned if available."
                                                  (float-time
                                                   (date-to-time created))))
                                          'font-lock-face 'forge-post-date))))))
-              (add-face-text-property 0 (length heading)
-                                      'magit-diff-hunk-heading t heading)
+              (font-lock-append-text-property
+               0 (length heading)
+               'font-lock-face 'magit-diff-hunk-heading heading)
               (magit-insert-heading heading))
             (insert (forge--fontify-markdown body) "\n\n"))))
       (when (and (display-images-p)


### PR DESCRIPTION
Unless I have missed something, `forge-post-author` and `forge-post-date` currently do not show up in topic posts.  The commit message provides my attempt at an explanation.

Let me know if something is amiss.  Two additional things I considered while working on this, but have not included in this initial PR:

1. defining two new faces, `forge-post-heading`, `forge-post-heading-highlight`; would inherit the current Magit faces by default, and the latter would have `:foreground unspecified`, plus a caveat in the docstring directed at theme authors, explaining the consequence of specifying a `:foreground`;

2. adding caveats in the docstrings of `forge-post-author` & `forge-post-date`; likewise, explaining to theme authors that attributes of `magit-diff-hunk-heading-highlight` will have higher priority, as a section's `heading-highlight-face` is applied via an overlay.

Hoping what I observe does not stem from a pilot error.  Just in case:

* `C-u M-x emacs-version`
> GNU Emacs 30.0.50 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.24.37, cairo version 1.17.8) of 2023-03-26

* `C-u M-x magit-version`
> Magit 20230323.1801 [>= 3.3.0.50-git], Git 2.40.0, Emacs 30.0.50, gnu/linux

* Forge commit used for testing:
> 2023-03-19 "Use magit--insert-log instead of deprecated magit-insert-log" (e82b45f)

Thanks for your time; first PR sent via Forge btw, thanks for this package 🙏