### PR TITLE
fix(depends): add `emacsql-sqlite-module`

### DIFF
--- a/forge-pkg.el
+++ b/forge-pkg.el
@@ -5,6 +5,7 @@
     (closql         "20230407")
     (dash           "2.19.1")
     (emacsql        "20230409")
+    (emacsql-sqlite-module "20230409.1847")
     (ghub           "20220621")
     (let-alist      "1.0.6")
     (magit          "20230319")


### PR DESCRIPTION
Forge requires `emacsql-sqlite-module` though,
The dependency was omitted.

---

I was going to write a bug report on the issue and I came up with a solution,
I'm going to submit it as a PR.

I was writing a report to write in an issue,
I'm attaching that as well.

# what behavior you expected

Forge has been working fine up until now.
However, I'm not sure if it's Emacs, [magit](https://github.com/magit/magit), [emacsql](https://github.com/magit/emacsql/), or Forge,
I don't know which update is the cause,
I don't know which update caused it, but it stopped working.

I was wondering if I should create the issue in emacsql,
I'm not sure if it's a backend issue or not,
so I'll put it where I can see where the problem is happening.

# what behavior you observed

Error message,

~~~
transient-setup: Cannot open load file: No such file or directory, sqlite3
~~~

will be output.

# how we can reproduce the issue

In my environment,

Running forge-related commands such as `(forge-dispatch)`

and other forge-related commands in my environment.

My Emacs configuration file is available on GitHub.

[ncaq/.emacs.d: My Emacs config](https://github.com/ncaq/.emacs.d)

## Execution environment

### Gentoo GNU/Linux

~~~
~
2023-04-16T14:02:39 ❯ uname -a
Linux bullet 6.1.19-gentoo #2 SMP PREEMPT_DYNAMIC Sun Mar 19 09:34:44 JST 2023 x86_64 AMD Ryzen 9 7950X 16-Core Processor AuthenticAMD GNU/Linux

~
2023-04-16T14:02:50 ❯ type emacs
emacs is /usr/bin/emacs

~
2023-04-16T14:02:56 ❯ type gcc
gcc is /usr/bin/gcc

~
2023-04-16T14:02:58 ❯ type sqlite3
sqlite3 is /usr/bin/sqlite3

~
2023-04-16T14:03:01 ❯ echo $PATH
/home/ncaq/.local/share/zinit/polaris/bin:/home/ncaq/.zsh.d/bin:/home/ncaq/.local/bin:/home/ncaq/.yarn/bin:/home/ncaq/.local/share/gem/ruby/3.2.0/bin:/home/ncaq/.opam/default/bin:/home/ncaq/.cargo/bin:/home/ncaq/.cabal/bin:/home/ncaq/.ghcup/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/opt/bin:/usr/lib/llvm/16/bin:/usr/lib/llvm/15/bin:/opt/cuda/bin
~~~

### How to install Emacs

I use Emacs v28 installed from Gentoo's Portage with the `emerge` command.
Version 28 is the latest unstable version available in the official Portage repository.
Version 29 is hard-masked as experimental or problematic and should not be used.

Disclosure of USE flag settings on Portage.

~~~
2023-04-16T13:46:57 ❯ equ emacs
[ Legend : U - final flag setting for installation]
[        : I - package is installed with flag     ]
[ Colors : set, unset                             ]
 * Found these USE flags for app-editors/emacs-28.3_rc1-r2:
 U I
 - - Xaw3d               : Add support for the 3d athena widget set
 + + acl                 : Add support for Access Control Lists
 + + alsa                : Add support for media-libs/alsa-lib (Advanced Linux Sound Architecture)
 - - athena              : Enable the MIT Athena widget set (x11-libs/libXaw)
 + + cairo               : Enable support for the cairo graphics library
 + + dbus                : Enable dbus support for anything that needs it (gpsd, gnomemeeting, etc)
 + + dynamic-loading     : Enable loading of dynamic libraries (modules) at runtime
 - - games               : Support shared score files for games
 + + gfile               : Use gfile (dev-libs/glib) for file notification
 + + gif                 : Add GIF image support
 + + gmp                 : Use the GNU multiple precision arithmetic library (dev-libs/gmp) instead of the bundled mini-gmp subset
 + + gpm                 : Add support for sys-libs/gpm (Console-based mouse driver)
 - - gsettings           : Use gsettings (dev-libs/glib) to read the system font name
 + + gtk                 : Add support for x11-libs/gtk+ (The GIMP Toolkit)
 + + gui                 : Enable support for a graphical user interface
 - - gzip-el             : Compress bundled Emacs Lisp source
 + + harfbuzz            : Use media-libs/harfbuzz as text shaping engine
 + + imagemagick         : Use media-gfx/imagemagick for image processing
 + + inotify             : Enable inotify filesystem monitoring support
 + + jit                 : Compile with Emacs Lisp native compiler support via libgccjit
 + + jpeg                : Add JPEG image support
 + + json                : Compile with native JSON support using dev-libs/jansson
 - - kerberos            : Add kerberos support
 + + lcms                : Add lcms support (color management engine)
 + + libxml2             : Use dev-libs/libxml2 to parse XML instead of the internal Lisp implementations
 - - livecd              : !!internal use only!! DO NOT SET THIS FLAG YOURSELF!, used during livecd building
 - - m17n-lib            : Enable m17n-lib support
 - - mailutils           : Retrieve e-mail using net-mail/mailutils instead of the internal movemail substitute
 - - motif               : Add support for the Motif toolkit
 + + png                 : Add support for libpng (PNG images)
 + + sound               : Enable sound support
 + + source              : Install C source files and make them available for find-function
 + + ssl                 : Add support for SSL/TLS connections (Secure Socket Layer / Transport Layer Security)
 + + svg                 : Add support for SVG (Scalable Vector Graphics)
 + + systemd             : Enable use of systemd-specific libraries and features like socket activation or session tracking
 + + threads             : Add elisp threading support
 + + tiff                : Add support for the TIFF image format
 + + toolkit-scroll-bars : Use the selected toolkit's scrollbars in preference to Emacs' own scrollbars
 - - wide-int            : Prefer wide Emacs integers (typically 62-bit). This option has an effect only on architectures where "long" and "long long" types have different size.
 + + xft                 : Build with support for XFT font renderer (x11-libs/libXft)
 + + xpm                 : Add support for XPM graphics format
 + + xwidgets            : Enable use of GTK widgets in Emacs buffers (requires GTK3)
 + + zlib                : Add support for zlib (de)compression
~~~

## Emacs build settings and execution environment variables.

~~~elisp
ELISP> (emacs-version)
"GNU Emacs 28.3 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.24.37, cairo version 1.17.8)
 of 2023-04-15"
ELISP> system-configuration-options
"--prefix=/usr --build=x86_64-pc-linux-gnu --host=x86_64-pc-linux-gnu --mandir=/usr/share/man --infodir=/usr/share/info --datadir=/usr/share --sysconfdir=/etc --localstatedir=/var/lib --datarootdir=/usr/share --disable-silent-rules --docdir=/usr/share/doc/emacs-28.3_rc1-r2 --htmldir=/usr/share/doc/emacs-28.3_rc1-r2/html --libdir=/usr/lib64 --program-suffix=-emacs-28 --includedir=/usr/include/emacs-28 --infodir=/usr/share/info/emacs-28 --localstatedir=/var --enable-locallisppath=/etc/emacs:/usr/share/emacs/site-lisp --without-compress-install --without-hesiod --without-pop --with-file-notification=inotify --with-pdumper --enable-acl --with-dbus --with-modules --without-gameuser --with-libgmp --with-gpm --with-native-compilation --with-json --without-kerberos --without-kerberos5 --with-lcms2 --with-xml2 --without-mailutils --without-selinux --with-gnutls --with-libsystemd --with-threads --without-wide-int --with-sound=alsa --with-zlib --with-x --without-ns --without-gconf --without-gsettings --with-toolkit-scroll-bars --with-gif --with-jpeg --with-png --with-rsvg --with-tiff --with-xpm --with-imagemagick --with-xft --with-cairo --with-harfbuzz --without-libotf --without-m17n-flt --with-x-toolkit=gtk3 --with-xwidgets --with-dumping=pdumper 'CFLAGS=-pipe -O2 -fomit-frame-pointer -march=native' 'LDFLAGS=-Wl,-O1 -Wl,--as-needed'"
ELISP> exec-path
("/home/ncaq/.local/share/zinit/polaris/bin/" "/home/ncaq/.zsh.d/bin/" "/home/ncaq/.local/bin/" "/home/ncaq/.yarn/bin/" "/home/ncaq/.cargo/bin/" "/home/ncaq/.local/share/gem/ruby/3.2.0/bin/" "/home/ncaq/.opam/default/bin/" "/home/ncaq/.cabal/bin/" "/home/ncaq/.ghcup/bin/" "/usr/local/sbin/" "/usr/local/bin/" "/usr/bin/" "/opt/bin/" "/usr/lib/llvm/16/bin/" "/usr/lib/llvm/15/bin/" "/opt/cuda/bin/" "/usr/libexec/emacs/28.3/x86_64-pc-linux-gnu/")
ELISP> package-selected-packages
(lsp-haskell forge git-modes ts-comint yarn-mode yaml-mode json-mode web-mode prettier add-node-modules-path reformatter swift-mode sbt-mode scala-mode rustic flycheck-raku raku-mode ein lsp-pyright pipenv poetry python-isort elpy dune-format dune tuareg markdown-mode groovy-mode dap-mode lsp-ui clang-format ccls company-dcd dfmt lsp-java shakespeare-mode haskell-mode elm-mode macrostep flycheck-package elisp-slime-nav docker-compose-mode dockerfile-mode d-mode systemd ssh-config-mode robots-txt-mode powershell nginx-mode mediawiki julia-mode graphviz-dot-mode go-mode egison-mode dotenv-mode csv-mode csharp-mode bnf-mode apache-mode quickrun flycheck lsp-mode which-key symbolword-mode multiple-cursors google-this expand-region editorconfig auto-sudoedit envrc mozc-im docker git-link git-gutter magit undo-tree string-inflection smartparens yasnippet-snippets yasnippet company-posframe company-quickhelp company smart-jump rg helpful helm-ls-git helm-swoop helm-descbinds helm recentf-remove-sudo-tramp-prefix recentf-ext anzu volatile-highlights rainbow-mode rainbow-delimiters solarized-theme popup f exec-path-from-shell gcmh leaf-tree leaf-convert diminish blackout el-get leaf-keywords)
~~~

## What I tried

I knew that it seems to be necessary to compile the C language natively during installation,
I tried removing all elpa, etc. once,
No effect.

So I tried manually installing the `emacsql-sqlite-module`, which seemed to be needed,
It worked, so I decided to send a PR to add the dependency.

This just made it OK in my environment,
It is a bit of a mystery if it works with Emacs v29, etc.

# backtrace

~~~
Debugger entered--Lisp error: (file-missing "Cannot open load file" "そのようなファイルやディレクトリはありません" "sqlite3")
  require(sqlite3)
  #f(compiled-function (#<emacsql-sqlite-module-connection emacsql-sqlite-module-connection-15800c07d22e> (:file "/home/ncaq/.emacs.d/forge-database.sqlite"))
  apply(#f(compiled-function
  #f(compiled-function (&rest args) #<bytecode -0x109535e35d17a32f>)(#<emacsql-sqlite-module-connection emacsql-sqlite-module-connection-15800c07d22e> (:file "/home/ncaq/.emacs.d/forge-database.sqlite"))
  apply(#f(compiled-function (&rest args) #<bytecode -0x109535e35d17a32f>) #<emacsql-sqlite-module-connection emacsql-sqlite-module-connection-15800c07d22e> (:file "/home/ncaq/.emacs.d/forge-database.sqlite"))
  initialize-instance(#<emacsql-sqlite-module-connection emacsql-sqlite-module-connection-15800c07d22e> (:file "/home/ncaq/.emacs.d/forge-database.sqlite"))
  #f(compiled-function (class &rest slots) "Default constructor for CLASS `eieio-default-superclass'.\nSLOTS are the initialization slots used by `initialize-instance'.\nThis static method is called when an object is constructed.\nIt allocates the vector used to represent an EIEIO object, and then\ncalls `initialize-instance' on that object." #<bytecode 0x17c82c02410abab7>)(emacsql-sqlite-module-connection :file "/home/ncaq/.emacs.d/forge-database.sqlite")
  apply(#f(compiled-function (class &rest slots) "Default constructor for CLASS `eieio-default-superclass'.\nSLOTS are the initialization slots used by `initialize-instance'.\nThis static method is called when an object is constructed.\nIt allocates the vector used to represent an EIEIO object, and then\ncalls `initialize-instance' on that object." #<bytecode 0x17c82c02410abab7>) emacsql-sqlite-module-connection (:file "/home/ncaq/.emacs.d/forge-database.sqlite"))
  make-instance(emacsql-sqlite-module-connection :file "/home/ncaq/.emacs.d/forge-database.sqlite")
  #f(compiled-function (class &optional livep connection-class) #<bytecode 0x3984b1bf320b103>)(forge-database nil nil)
  apply(#f(compiled-function (class &optional livep connection-class) #<bytecode 0x3984b1bf320b103>) forge-database (nil nil))
  closql-db(forge-database nil nil)
  forge-db()
  forge-connect-database-once()
  run-hooks(change-major-mode-after-body-hook special-mode-hook magit-section-mode-hook magit-mode-hook magit-status-mode-hook)
  apply(run-hooks (change-major-mode-after-body-hook special-mode-hook magit-section-mode-hook magit-mode-hook magit-status-mode-hook))
  run-mode-hooks(magit-status-mode-hook)
  magit-status-mode()
  magit-setup-buffer-internal(magit-status-mode nil ((magit-buffer-diff-args ("--no-ext-diff")) (magit-buffer-diff-files nil) (magit-buffer-log-args ("-n256" "--decorate")) (magit-buffer-log-files nil)))
  magit-status-setup-buffer("/home/ncaq/.emacs.d/")
  magit-status(nil ((7 . 4) (("/home/ncaq/.emacs.d/" . config) . #<hash-table equal 42/65 0x15800c0678df>) (("/home/ncaq/.emacs.d/" . magit-toplevel) . "/home/ncaq/.emacs.d/") (("/home/ncaq/.emacs.d/" "rev-parse" "--show-cdup") . "") (("/home/ncaq/.emacs.d/" "rev-parse" "--show-toplevel") . "/home/ncaq/.emacs.d")))
  funcall-interactively(magit-status nil ((7 . 4) (("/home/ncaq/.emacs.d/" . config) . #<hash-table equal 42/65 0x15800c0678df>) (("/home/ncaq/.emacs.d/" . magit-toplevel) . "/home/ncaq/.emacs.d/") (("/home/ncaq/.emacs.d/" "rev-parse" "--show-cdup") . "") (("/home/ncaq/.emacs.d/" "rev-parse" "--show-toplevel") . "/home/ncaq/.emacs.d")))
  command-execute(magit-status)
~~~