### PR TITLE
Adjust GitLab URLs for routing changes

### DIFF
--- a/lisp/forge-gitlab.el
+++ b/lisp/forge-gitlab.el
@@ -31,17 +31,17 @@
 ;;; Class
 
 (defclass forge-gitlab-repository (forge-repository)
-  ((issues-url-format         :initform "https://%h/%o/%n/issues")
-   (issue-url-format          :initform "https://%h/%o/%n/issues/%i")
-   (issue-post-url-format     :initform "https://%h/%o/%n/issues/%i#note_%I")
-   (pullreqs-url-format       :initform "https://%h/%o/%n/merge_requests")
-   (pullreq-url-format        :initform "https://%h/%o/%n/merge_requests/%i")
-   (pullreq-post-url-format   :initform "https://%h/%o/%n/merge_requests/%i#note_%I")
-   (commit-url-format         :initform "https://%h/%o/%n/commit/%r")
-   (branch-url-format         :initform "https://%h/%o/%n/commits/%r")
+  ((issues-url-format         :initform "https://%h/%o/%n/-/issues")
+   (issue-url-format          :initform "https://%h/%o/%n/-/issues/%i")
+   (issue-post-url-format     :initform "https://%h/%o/%n/-/issues/%i#note_%I")
+   (pullreqs-url-format       :initform "https://%h/%o/%n/-/merge_requests")
+   (pullreq-url-format        :initform "https://%h/%o/%n/-/merge_requests/%i")
+   (pullreq-post-url-format   :initform "https://%h/%o/%n/-/merge_requests/%i#note_%I")
+   (commit-url-format         :initform "https://%h/%o/%n/-/commit/%r")
+   (branch-url-format         :initform "https://%h/%o/%n/-/commits/%r")
    (remote-url-format         :initform "https://%h/%o/%n")
-   (create-issue-url-format   :initform "https://%h/%o/%n/issues/new")
-   (create-pullreq-url-format :initform "https://%h/%o/%n/merge_requests/new")
+   (create-issue-url-format   :initform "https://%h/%o/%n/-/issues/new")
+   (create-pullreq-url-format :initform "https://%h/%o/%n/-/merge_requests/new")
    (pullreq-refspec :initform "+refs/merge-requests/*/head:refs/pullreqs/*")))
 
 ;;; Pull


### PR DESCRIPTION
GitLab has been slowly rolling out a change to their URLs to improve
routing performance: https://gitlab.com/gitlab-org/gitlab/-/issues/214217

The gist is that they are putting dashes after the project name and any
subgroup(s), so that they can avoid DB lookups in order to handle
routing.

Recently, the old URL format stopped resolving at least for issues,
commits, and merge requests, see for example:

- https://gitlab.com/gitlab-org/gitlab/issues/214217 vs https://gitlab.com/gitlab-org/gitlab/-/issues/214217
- https://gitlab.com/gitlab-org/gitlab/commit/fedcd95e9736a273d5bad1d4d84c7477c39a623e vs
https://gitlab.com/gitlab-org/gitlab/-/commit/fedcd95e9736a273d5bad1d4d84c7477c39a623e
- https://gitlab.com/gitlab-org/gitlab/merge_requests/121592 vs https://gitlab.com/gitlab-org/gitlab/-/merge_requests/121592

The result is that actions like `forge-browse-issue` or
`forge-browse-pullreq` are broken for GitLab.

This commit updates the URL templates for GitLab to use the new, dashed
format.