### PR TITLE
Support for CI status (addresses #92)

### DIFF
--- a/lisp/forge-db.el
+++ b/lisp/forge-db.el
@@ -51,7 +51,7 @@
    (object-class :initform 'forge-repository)
    (file         :initform 'forge-database-file)
    (schemata     :initform 'forge--db-table-schemata)
-   (version      :initform 9)))
+   (version      :initform 10)))
 
 (defvar forge--override-connection-class nil)
 
@@ -346,6 +346,15 @@
       [pullreq] :references pullreq [id]
       :on-delete :cascade))
 
+    (workflow
+     [(class :not-null)
+      (id :not-null :primary-key)
+      commit
+      name
+      conclusion
+      ;; runs
+      ])
+
     (revnote
      [(class :not-null)
       (id :not-null :primary-key)
@@ -428,7 +437,13 @@
         (emacsql db [:alter-table pullreq :add-column their-id :default nil])
         (emacsql db [:alter-table issue   :add-column their-id :default nil])
         (closql--db-set-version db (setq version 9))
-        (message "Upgrading Forge database from version 8 to 9...done")))
+        (message "Upgrading Forge database from version 8 to 9...done"))
+      (when (= version 9)
+        (message "Upgrading Forge database from version 9 to 10...")
+        (emacsql db [:create-table workflow $S1]
+                 (cdr (assq 'workflow forge--db-table-schemata)))
+        (closql--db-set-version db (setq version 10))
+        (message "Upgrading Forge database from version 9 to 10...done")))
     (cl-call-next-method)))
 
 (defun forge--backup-database (db)

--- a/lisp/forge-pullreq.el
+++ b/lisp/forge-pullreq.el
@@ -88,7 +88,19 @@
    (updated              :initarg :updated)
    (body                 :initarg :body)
    (edits)
-   (reactions)
+   (reactions)))
+
+(defclass forge-workflow (forge-topic)
+  ((closql-table         :initform 'workflow)
+   (closql-primary-key   :initform 'id)
+   (closql-order-by      :initform [(asc id)])
+   (closql-class-prefix  :initform "forge-")
+   ;; actual data
+   (id                   :initarg :id)
+   (commit               :initarg :commit)
+   (name                 :initarg :name)
+   (conclusion           :initarg :conclusion)
+   ;; (runs                 :closql-table (workflow-status workflow-name))
    ))
 
 ;;; Query
@@ -118,6 +130,11 @@
   (closql-get (forge-db)
               (oref post pullreq)
               'forge-pullreq))
+
+(cl-defmethod forge-get-workflow ((repo forge-repository) commit-id title)
+  (closql-get (forge-db)
+              (forge--object-id 'forge-workflow repo (format "%s:%s" commit-id title))
+              'forge-workflow))
 
 (cl-defmethod forge-ls-pullreqs ((repo forge-repository) &optional type select)
   (forge-ls-topics repo 'forge-pullreq type select))


### PR DESCRIPTION
This PR is still a work in progress. Everything is subject to change.

This PR adds initial support for reporting workflow statuses. At the moment, I have only implemented basic support for the Github workflow API. Support for other forges may make more sense in a separate pull request.

## Todo

- [ ] Runs (essentially subtasks of a workflow)
  - [ ] Store run name + status in database
  - [ ] Think about how to handle logs. I don't think storing them in the database is ideal, but it would be nice to be able to view them
- [ ] Display workflow information in PR details page
- [ ] Look at Gitlab API to see if the database information is generalizable across forges.
- [ ] Change what we use as workflow id from `commit + name` to something else. maybe the API node id?

## Changes
I've added `workflow` to the database schema which stores information about workflow runs. This bumps the database schema version up to 10. I like keeping the workflow table detached from the pullreq table because it makes it easier in the future to add support for reporting per-commit workflow statuses.

At the moment, workflow information is downloaded alongside pull request information. I only pull information about the most head-rev commit in the PR. This is done with a separate query to the API for now. It should be merged with the pull request query eventually, but this necessitates a change to ghub.

Workflow information is displayed alongside pull requests in the main view. This works by querying the database for workflow runs that have the same commit as the head-rev of the PR.