### PR TITLE
manual: Fix documented keybinds for branching

### DIFF
--- a/docs/forge.org
+++ b/docs/forge.org
@@ -503,7 +503,7 @@ same transient prefix commands as the suffix commands used to create
 and check out branches and work trees in a more generic fashion
 (~magit-branch~ on ~b~ and ~magit-worktree~ on ~%~).
 
-- Key: b N (forge-branch-pullreq) ::
+- Key: b F (forge-branch-pullreq) ::
 
   This command creates and configures a new branch from a pull-request,
   creating and configuring a new remote if necessary.
@@ -587,7 +587,7 @@ and check out branches and work trees in a more generic fashion
     the variable ~branch.<name>.pullRequestRemote~ is set to the remote
     on which the pull-request branch is located.
 
-- Key: b n (forge-checkout-pullreq) ::
+- Key: b f (forge-checkout-pullreq) ::
 
   This command creates and configures a new branch from a pull-request
   the same way ~forge-branch-pullreq~ does.  Additionally it checks out

--- a/docs/forge.texi
+++ b/docs/forge.texi
@@ -723,8 +723,8 @@ and check out branches and work trees in a more generic fashion
 (@code{magit-branch} on @code{b} and @code{magit-worktree} on @code{%}).
 
 @table @asis
-@item @kbd{b N} (@code{forge-branch-pullreq})
-@kindex b N
+@item @kbd{b F} (@code{forge-branch-pullreq})
+@kindex b F
 @findex forge-branch-pullreq
 This command creates and configures a new branch from a pull-request,
 creating and configuring a new remote if necessary.
@@ -824,8 +824,8 @@ the variable @code{branch.<name>.pullRequestRemote} is set to the remote
 on which the pull-request branch is located.
 @end itemize
 
-@item @kbd{b n} (@code{forge-checkout-pullreq})
-@kindex b n
+@item @kbd{b f} (@code{forge-checkout-pullreq})
+@kindex b f
 @findex forge-checkout-pullreq
 This command creates and configures a new branch from a pull-request
 the same way @code{forge-branch-pullreq} does.  Additionally it checks out

--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -584,7 +584,7 @@ is called and a topic object is returned if available."
         (overlay-put o 'help-echo description)))))
 
 (defun forge--sanitize-color (color)
-  (cond ((x-color-values color) color)
+  (cond ((color-values color) color)
         ;; Discard alpha information.
         ((string-match-p "\\`#.\\{4\\}\\'" color) (substring color 0 3))
         ((string-match-p "\\`#.\\{8\\}\\'" color) (substring color 0 6))
@@ -598,7 +598,7 @@ is called and a topic object is returned if available."
 (defun forge--x-color-luminance (color)
   "Calculate the luminance of a color string (e.g. \"#ffaa00\", \"blue\").
 Return a value between 0 and 1."
-  (let ((values (x-color-values color)))
+  (let ((values (color-values color)))
     (forge--color-luminance (/ (nth 0 values) 256.0)
                             (/ (nth 1 values) 256.0)
                             (/ (nth 2 values) 256.0))))


### PR DESCRIPTION
I noticed the keybinds in the manual aren't up to date with what's in the code, this PR changes the documented keybind  for creating new branches from pull requests from `b n/N` -> `b f/F`.