### PR TITLE
forge-browse-remote: auto-accept single candidate

### DIFF
--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -309,7 +309,7 @@ argument also offer closed pull-requests."
 ;;;###autoload
 (defun forge-browse-remote (remote)
   "Read a REMOTE and visit it using a browser."
-  (interactive (list (magit-read-remote "Browse remote")))
+  (interactive (list (magit-read-remote "Browse remote" nil t)))
   (browse-url (forge-get-url :remote remote)))
 
 ;;;###autoload


### PR DESCRIPTION
Using `N b r` in a repository with only a single 'origin' remote would still prompt the user to select a remote to browse.

Given this is a non-destructive action (and not something like `magit-remote-prune', for example), there is no need to prompt when there's only one option.
