### PR TITLE
Allow browsing the remote from `forge-dispatch` even when repo is not in the database

### DIFF
--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -102,6 +102,7 @@ Takes the pull-request as only argument and must return a directory."
                      "Not inside a Git repository"))
     :if-not forge--get-full-repository
     ("a" "add repository to database" forge-add-repository)
+    ("b" "browse remote"              forge-browse-remote)
     ("f" "fetch notifications"        forge-pull-notifications)
     ("l" "list notifications"         forge-list-notifications)]])
 


### PR DESCRIPTION
This pull request allows the user to browse the remote from the Forge dispatcher even when the repository has not been added to the database. Browsing a remote is a very common operation and it seems like it should be possible to perform it without having to add a repo (or define a custom dispatcher or key binding).