### PR TITLE
Fix #639

### DIFF
--- a/lisp/forge-repo.el
+++ b/lisp/forge-repo.el
@@ -118,7 +118,7 @@
     remote))
 
 (cl-defmethod forge-get-repository ((_(eql :id)) id)
-  (closql-get (forge-db) id 'forge-repository))
+  (closql-get (forge-db) (substring-no-properties id) 'forge-repository))
 
 (cl-defmethod forge-get-repository ((_ null) &optional remote)
   ;; Avoid matching the ((host owner name) list) ...) method.
@@ -179,6 +179,9 @@ or signal an error, depending on DEMAND."
 
 Return the repository identified by HOST, OWNER and NAME.
 See `forge-alist' for valid Git hosts."
+  (setq host  (substring-no-properties host))
+  (setq owner (substring-no-properties owner))
+  (setq name  (substring-no-properties name))
   (unless (memq demand '(:tracked :tracked? :known? :insert! :stub :stub?))
     (if-let ((new (pcase demand
                     ('t      :tracked)

--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -513,27 +513,24 @@ can be selected from the start."
                     (use-local-map (make-composed-keymap
                                     forge-read-topic-minibuffer-map
                                     (current-local-map))))
-                (magit-completing-read
-                 (concat prompt
-                         (substitute-command-keys
-                          (format "\\<forge-read-topic-minibuffer-map>\
+                (let ((minibuffer-allow-text-properties t))
+                  (magit-completing-read
+                   (concat prompt
+                           (substitute-command-keys
+                            (format "\\<forge-read-topic-minibuffer-map>\
  (\\[forge-read-topic-lift-limit] for all)")))
-                 (let (all-choices)
-                   (lambda (&rest _)
-                     (cond
-                      (all-choices)
-                      (forge-limit-topic-choices choices)
-                      (t
-                       (forge--replace-minibuffer-prompt prompt)
-                       (setq all-choices (mapcar #'forge--format-topic-choice
-                                                 (funcall all repo)))))))
-                 nil t nil nil default))
+                   (let (all-choices)
+                     (lambda (&rest _)
+                       (cond
+                        (all-choices)
+                        (forge-limit-topic-choices choices)
+                        (t
+                         (forge--replace-minibuffer-prompt prompt)
+                         (setq all-choices (mapcar #'forge--format-topic-choice
+                                                   (funcall all repo)))))))
+                   nil t nil nil default)))
             (magit-completing-read prompt choices nil t nil nil default))))
     (get-text-property 0 'forge--topic-id choice)))
-
-(setq minibuffer-allow-text-properties
-      (cons 'forge--topic-id
-            minibuffer-allow-text-properties))
 
 (defvar-keymap forge-read-topic-minibuffer-map
   "+" #'forge-read-topic-lift-limit)


### PR DESCRIPTION
Closes #639.

At https://github.com/minad/jinx/issues/140#issuecomment-1978951419 @minad wrote (emphasis mine):

> This is a bug in Forge, which will create problems for many packages.

Forge sets that variable to a list beginning with `forge--topic-id`, so when the value ends up being `t`, then another package must also be messing with the global value, I saw Gnus mentioned.  Anyway, what I meant to ask about is this:

> `minibuffer-allow-text-properties` should only be let-bound around `read-from-minibuffer` or `completing-read`,

This pr does that.

> or if possible should be set only locally in the minibuffer via `minibuffer-setup-hook`.

That doesn't seem to work for me.

> **Also note that `completing-read` does not necessarily preserve text properties (even with `minibuffer-allow-text-properties=t`!),** which means that code depending on properties during completion is most likely incorrect.

@minad Could you please say more about when this setting may be ignored?  I.e., is the third commit in this pull-request necessary just to be on the safe side?  Thanks (again ;P (see email)) for your help!

The reason I am passing along the "actual" value using a text property, is, that while I can pass an alist as the `collection` argument of `completing-read`, something equivalent doesn't seem to be possible when using programmed completion.  Programmed completion is needed both for performance reasons, and to avoid overwhelming the users with too many choices (while allowing them to extend the set of completion candidates, iff needed).