### PR TITLE
Respecting `auto-revert-remote-files` in `forge-bug-reference-setup`

### DIFF
--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -1735,6 +1735,9 @@ enable `bug-reference-mode' or `bug-reference-prog-mode' and
 modify `bug-reference-bug-regexp' if appropriate."
   (unless (or bug-reference-url-format
               (not (forge-db t))
+              (and (not auto-revert-remote-files) ; see magit's #5422
+                   buffer-file-name
+                   (file-remote-p buffer-file-name))
               ;; TODO Allow use in these modes again.
               (derived-mode-p 'forge-topics-mode 'forge-notifications-mode))
     (magit--with-safe-default-directory nil


### PR DESCRIPTION
Fixes a similar issue as https://github.com/magit/magit/issues/5222, where, when using tramp, forge would do substantial unnecessary work inside `forge-bug-reference-setup`, slowing down the connection or even hanging.

To fix this issue, changes similar to the original magit commit (see https://github.com/magit/magit/commit/61c051ea1cda5fe6c9404cb5ae228088d2e254f0) could easily be repeated, basically shortening out the `unless` within `forge-bug-reference-setup`.
