### PR TITLE
Change the suffix for magit-dispatch to avoid an error

### DIFF
--- a/lisp/forge.el
+++ b/lisp/forge.el
@@ -124,7 +124,7 @@ is loaded, then `magit-mode-map' ends up being modified anyway.")
   (keymap-set magit-commit-section-map "C-c C-v" #'forge-visit-topic)
   (keymap-set magit-branch-section-map "C-c C-v" #'forge-visit-topic)
 
-  (transient-insert-suffix 'magit-dispatch "o"
+  (transient-insert-suffix 'magit-dispatch '(0 -1 -1)
     '("N" "Forge" forge-dispatch))
 
   (transient-append-suffix 'magit-fetch "m" '("n" forge-pull))


### PR DESCRIPTION
I have updated to the last version of magit and forge and I'm finding the following error:
```
Error (use-package): forge/:catch: Cannot insert ("N" "Forge" forge-dispatch) into magit-dispatch; o not found
```
There is a related issue: https://github.com/magit/forge/issues/388
and this solution is the same as highlighted in one of the comments:
https://github.com/magit/forge/issues/388#issuecomment-899708964
After this change the error doesn't appear anymore.