### PR TITLE
Offer blank option in addition to templates

### DIFF
--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -1933,8 +1933,11 @@ alist, containing just `text' and `position'.")
 
 (cl-defmethod forge--topic-template ((repo forge-repository)
                                      (class (subclass forge-topic)))
-  (let ((choices (and (not (eq class 'forge-discussion))
-                      (forge--topic-templates-data repo class))))
+  (let* ((supported-topic? (not (eq class 'forge-discussion)))
+         (template-choices (when supported-topic?
+                             (forge--topic-templates-data repo class)))
+         (choices (and template-choices
+                       (append template-choices '(((prompt . "Blank")))))))
     (if (cdr choices)
         (let ((c (magit-completing-read
                   (pcase class


### PR DESCRIPTION
## Summary
Allow for choosing "Blank" as an alternative to templates when they're available.

This PR makes it so that if there are templates available for Issues or PR topics, then an additional "blank" option is offered.

## Reasoning
Sometimes one wants to create an issue or pull request without using a template. This also aligns with how github presents it in their web app:
<img width="889" alt="image" src="https://github.com/user-attachments/assets/625ddf8c-b5c4-4ed6-b84c-7b95a4a516af" />

## Additional notes
I saw that `'forge-discussion` is a handled topic in the case statement for the completing-read below, but it was not permitted to get into that branch because of the equality check. I assumed this meant that it's not something that's supported right now and may be later on and modeled it as such, but let me know if I was incorrect with that assumption.