### PR TITLE
forge--topic-parse-template: Fix parsing when there is no metadata

### DIFF
--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -1928,7 +1928,7 @@ When point is on the answer, then unmark it and mark no other."
           (text      . ,(magit--buffer-string (point) nil ?\n))
           (labels    . ,(ensure-list .labels))
           (assignees . ,(ensure-list .assignees))))
-    `((text . (magit--buffer-string)))))
+    `((text . ,(magit--buffer-string)))))
 
 (defun forge--topic-parse-buffer (&optional file)
   (save-match-data


### PR DESCRIPTION
The returned template alist should associate "text" with a string, not
with a function.