### PR TITLE
forge--fork-repository: Fix several issues

### DIFF
--- a/lisp/forge-github.el
+++ b/lisp/forge-github.el
@@ -1155,7 +1155,7 @@
   (with-slots (owner name apihost) repo
     (forge--ghub-post repo
       (format "/repos/%s/%s/forks" owner name)
-      (and (not (equal fork (ghub--username (ghub--host nil))))
+      (and (not (equal fork (ghub--username apihost)))
            `((organization . ,fork))))
     (ghub-wait (format "/repos/%s/%s" fork name)
                nil :auth 'forge :host apihost)))

--- a/lisp/forge-github.el
+++ b/lisp/forge-github.el
@@ -1152,12 +1152,13 @@
   (magit-call-git "fetch" "--prune" (oref repo remote)))
 
 (cl-defmethod forge--fork-repository ((repo forge-github-repository) fork)
-  (with-slots (owner name) repo
+  (with-slots (owner name apihost) repo
     (forge--ghub-post repo
       (format "/repos/%s/%s/forks" owner name)
       (and (not (equal fork (ghub--username (ghub--host nil))))
            `((organization . ,fork))))
-    (ghub-wait (format "/repos/%s/%s" fork name) nil :auth 'forge)))
+    (ghub-wait (format "/repos/%s/%s" fork name)
+               nil :auth 'forge :host apihost)))
 
 (cl-defmethod forge--merge-pullreq ((repo forge-github-repository)
                                     pullreq hash method)

--- a/lisp/forge-github.el
+++ b/lisp/forge-github.el
@@ -1152,9 +1152,8 @@
   (magit-call-git "fetch" "--prune" (oref repo remote)))
 
 (cl-defmethod forge--fork-repository ((repo forge-github-repository) fork)
-  (with-slots (owner name apihost) repo
-    (forge--ghub-post repo
-      (format "/repos/%s/%s/forks" owner name)
+  (with-slots (name apihost) repo
+    (forge--ghub-post repo "/repos/:owner/:name/forks"
       (and (not (equal fork (ghub--username apihost)))
            `((organization . ,fork))))
     (ghub-wait (format "/repos/%s/%s" fork name)

--- a/lisp/forge-gitlab.el
+++ b/lisp/forge-gitlab.el
@@ -597,7 +597,7 @@
       (and (not (equal fork (ghub--username apihost 'gitlab)))
            `((namespace . ,fork)))
       :noerror t)
-    (ghub-wait (format "/projects/%s%%2F%s" fork name)
+    (ghub-wait (format "/projects/%s%%2F%s" (string-replace "/" "%2F" fork) name)
                nil :auth 'forge :host apihost :forge 'gitlab)))
 
 (cl-defmethod forge--merge-pullreq ((_repo forge-gitlab-repository)

--- a/lisp/forge-gitlab.el
+++ b/lisp/forge-gitlab.el
@@ -594,7 +594,7 @@
 (cl-defmethod forge--fork-repository ((repo forge-gitlab-repository) fork)
   (with-slots (owner name apihost) repo
     (forge--glab-post repo (format "/projects/%s%%2F%s/fork" owner name)
-      (and (not (equal fork (ghub--username (ghub--host nil))))
+      (and (not (equal fork (ghub--username apihost 'gitlab)))
            `((namespace . ,fork)))
       :noerror t)
     (ghub-wait (format "/projects/%s%%2F%s" fork name)

--- a/lisp/forge-gitlab.el
+++ b/lisp/forge-gitlab.el
@@ -592,13 +592,13 @@
   (forge--topic-template-files-1 repo "md" ".gitlab/merge_request_templates"))
 
 (cl-defmethod forge--fork-repository ((repo forge-gitlab-repository) fork)
-  (with-slots (owner name) repo
+  (with-slots (owner name apihost) repo
     (forge--glab-post repo (format "/projects/%s%%2F%s/fork" owner name)
       (and (not (equal fork (ghub--username (ghub--host nil))))
            `((namespace . ,fork)))
       :noerror t)
     (ghub-wait (format "/projects/%s%%2F%s" fork name)
-               nil :auth 'forge :forge 'gitlab)))
+               nil :auth 'forge :host apihost :forge 'gitlab)))
 
 (cl-defmethod forge--merge-pullreq ((_repo forge-gitlab-repository)
                                     topic hash method)

--- a/lisp/forge-gitlab.el
+++ b/lisp/forge-gitlab.el
@@ -592,8 +592,8 @@
   (forge--topic-template-files-1 repo "md" ".gitlab/merge_request_templates"))
 
 (cl-defmethod forge--fork-repository ((repo forge-gitlab-repository) fork)
-  (with-slots (owner name apihost) repo
-    (forge--glab-post repo (format "/projects/%s%%2F%s/fork" owner name)
+  (with-slots (name apihost) repo
+    (forge--glab-post repo "/projects/:project/fork"
       (and (not (equal fork (ghub--username apihost 'gitlab)))
            `((namespace . ,fork)))
       :noerror t)


### PR DESCRIPTION
This addresses some issues encountered in `forge--fork-repository`:
+ The poll using `ghub-wait` was always targeting the forge's default host, and therefore timing out with an error message for other hosts.
+ The comparison of the fork destination would always be done against the username set for github's default host.
+ The Gitlab endpoints were not correctly escaped in case the owner or fork destination were a subgroup separated by a slash.