### PR TITLE
forge--ghub-type-symbol: Support the forgejo symbol

### DIFF
--- a/lisp/forge-repo.el
+++ b/lisp/forge-repo.el
@@ -550,6 +550,7 @@ forges and hosts."
     ('forge-github-repository    'github)
     ('forge-gitea-repository     'gitea)
     ('forge-gogs-repository      'gogs)
+    ('forge-forgejo-repository   'forgejo)
     ('forge-bitbucket-repository 'bitbucket)))
 
 ;;; _


### PR DESCRIPTION
Enables the Forgejo-based forges, to be merged together with https://github.com/magit/ghub/pull/177