### PR TITLE
Support GitLab issue templates without YAML frontmatter

### DIFF
--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -1960,7 +1960,7 @@ When point is on the answer, then unmark it and mark no other."
               (magit-git-insert "cat-file" "-p" file)
               (if (equal (file-name-nondirectory file) "config.yml")
                   (forge--topic-parse-template-config)
-                (list (forge--topic-parse-template)))))
+                (list (forge--topic-parse-template (file-name-base file))))))
           (forge--topic-template-files repo class)))
 
 (cl-defgeneric forge--topic-template-files (repo class))
@@ -1992,7 +1992,7 @@ When point is on the answer, then unmark it and mark no other."
                                       " — " .about)))))
              .contact_links))))
 
-(defun forge--topic-parse-template ()
+(defun forge--topic-parse-template (filename)
   (goto-char (point-min))
   (skip-chars-forward "\s\t\n\r")
   (if-let ((beg (and (looking-at "^---[\s\t]*$")
@@ -2006,11 +2006,15 @@ When point is on the answer, then unmark it and mark no other."
                                     :sequence-type 'list
                                     :null-object nil
                                     :false-object nil)
-        `((prompt    . ,(format "%s — %s"
-                                (and .name
-                                     (stringp .name)
-                                     (propertize .name 'face 'bold))
-                                .about))
+        `((prompt    . ,(cond
+                           ((and (stringp .name) (stringp .about)
+                             (format "%s — %s"
+                                 (and .name
+                                      (stringp .name)
+                                      (propertize .name 'face 'bold))
+                                 .about)))
+                           ((and (stringp .name) (propertize .name 'face 'bold)))
+                           ((and (stringp filename) (propertize filename 'face 'bold)))))
           (title     . ,(and .title
                              (stringp .title)
                              (string-trim .title)))
@@ -2030,7 +2034,8 @@ When point is on the answer, then unmark it and mark no other."
                                         repoid)
                          :test #'equal))
           (draft     . ,(and (booleanp .draft) .draft))))
-    `((text . ,(magit--buffer-string)))))
+    `((prompt . ,(propertize filename 'face 'bold))
+      (text . ,(magit--buffer-string)))))
 
 ;;; Bug-Reference
 


### PR DESCRIPTION
GitLab currently does not support YAML frontmatter in issue templates (see [gitlab#326905](https://gitlab.com/gitlab-org/gitlab/-/issues/326905)), but Magit Forge's `forge-create-issue` expects templates to have YAML headers with `name` and `about` fields. 

When using templates without YAML frontmatter, the issue selection interface shows unhelpful entries like for the repo I work with:

```
nil
nil - nil
```

This PR improves the template parsing logic to handle templates without YAML frontmatter and improves the display of incomplete template metadata.

### Cases handled:

| Template condition               | Before                             | After                              |
|----------------------------------|------------------------------------|------------------------------------|
| No YAML header                   | `nil`                              | `bug` (from filename)              |
| YAML with missing `name`/`about` | `nil - nil`                        | `feat` (from filename)             |
| YAML with only `name`            | `Bug Report - nil`                 | `Bug Report`                       |
| Complete YAML                    | `Bug Report - Create a bug report` | `Bug Report - Create a bug report` |


Since the change does not affect public forge API, do let me know if i should update the documentation.