### PR TITLE
docs: github.com > codeberg.com under "tell forge about the instance"

### DIFF
--- a/docs/forge.org
+++ b/docs/forge.org
@@ -479,7 +479,7 @@ at least enables the use of commands such as ~forge-browse~.
 A few hosts, which use partially supported forge types, are available
 out-of-the-box, because they have an entry in the default value of
 option ~forge-alist~ (also see its docstring).  For example, the entry
-for https://github.com in that variable looks like this:
+for https://codeberg.org in that variable looks like this:
 
 #+begin_src emacs-lisp
   ("codeberg.org"                     ; GITHOST

--- a/docs/forge.texi
+++ b/docs/forge.texi
@@ -570,7 +570,7 @@ at least enables the use of commands such as @code{forge-browse}.
 A few hosts, which use partially supported forge types, are available
 out-of-the-box, because they have an entry in the default value of
 option @code{forge-alist} (also see its docstring).  For example, the entry
-for @uref{https://github.com} in that variable looks like this:
+for @uref{https://codeberg.org} in that variable looks like this:
 
 @lisp
 ("codeberg.org"                     ; GITHOST


### PR DESCRIPTION
Fixes a minor tpyo in the text preceding the example entry for `codeberg.org` entry under `forge-alist` in the *Tell Forge about the Instance* section.

> Edit only "forge.org".  To update "forge.texi" run "make texi".

`forge.texi` is included, it was generated via `make texi` (based on looking at earlier PR #577 which also fixed a tpyo in the manual and included both `.org` and `.texi`). Hope that is correct.