### PR TITLE
forge--update-pullreq: Fetch and store review comments

### DIFF
--- a/lisp/forge-github.el
+++ b/lisp/forge-github.el
@@ -193,6 +193,20 @@
           (  assignees [(:edges t)] id)
           (  reviewRequests [(:edges t)]
              (requestedReviewer "... on User { id }\n"))
+          (  reviews [(:edges t)]
+             id
+             databaseId
+             (author login)
+             createdAt
+             updatedAt
+             ;; review is a start of threaded comments can be resolved
+             (  comments [(:edges t)]
+                id
+                databaseId
+                (author login)
+                createdAt
+                updatedAt
+                body))
           (  comments [(:edges t)]
              id
              databaseId
@@ -634,7 +648,8 @@
         (oset pullreq head-repo    .headRef.repository.nameWithOwner)
         (oset pullreq milestone    (forge--object-id repo-id .milestone.id))
         (oset pullreq body         (forge--sanitize-string .body))
-        (dolist (p .comments)
+        (dolist (p (append .comments
+                           (mapcar (lambda (r) (let-alist r (car .comments))) .reviews)))
           (let-alist p
             (closql-insert
              (forge-db)


### PR DESCRIPTION
Fetch and store review comments alongside with normal comments.

Before this change, the review comments are not visible in pullreq view like following

<img width="1267" height="1395" alt="image" src="https://github.com/user-attachments/assets/cb88daf4-260f-47cc-a9f7-39f974ea0e8c" />

