### PR TITLE
Improve default branch detection for pull requests

### DIFF
--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -664,9 +664,11 @@ With prefix argument MENU, also show the topic menu."
                           (d (and d (if (magit-remote-branch-p d)
                                         d
                                       (magit-get-upstream-branch d))))
-                          (d (or d (concat remote "/"
-                                           (or (oref repo default-branch)
-                                               "master")))))
+                          (d (or d
+                                 (and-let* ((b (oref repo default-branch)))
+                                   (car (member (concat remote "/" b) targets)))
+                                 (car (member (concat remote "/main") targets))
+                                 (car (member (concat remote "/master") targets)))))
                      (car (member d targets))))))
     (list source target)))
 


### PR DESCRIPTION
Currently only `master` is used as a last resort fallback. A lot of repos nowadays use `main` so I added `main` as well before `master`.