### PR TITLE
Format line variable

### DIFF
--- a/docs/forge.org
+++ b/docs/forge.org
@@ -1311,6 +1311,38 @@ then the remote is never removed.
   This option specifies the width of repository slugs (i.e.,
   "OWNER/NAME").
 
+- User Option: forge-topic-line-format ::
+
+  This option specifies the format for topic lines in topic and
+  notification lists.
+
+  The following ~%~-sequences are supported:
+
+  - ~%R~ The slug of the repository, padded to
+    ~forge-topic-repository-slug-width~, followed by a space.  This is
+    only non-empty in flat notification lists and in ungrouped, global
+    topic lists; elsewhere it expands to the empty string.
+  - ~%s~ The slug of the topic (e.g., "#123"), padded to the width
+    requested by the caller.
+  - ~%t~ The title of the topic.
+
+- User Option: forge-topic-slug-symbols ::
+
+  This option specifies the symbols used to prefix topic slugs, by
+  topic type.
+
+  Each entry maps a topic class (~forge-issue~, ~forge-pullreq~ or
+  ~forge-discussion~) to the symbol displayed in front of the topic's
+  number.  When the symbol is ~nil~, the slug provided by the forge is
+  used as-is; otherwise the forge's leading symbol is replaced with the
+  configured one at display time.
+
+  Note that forges use their own conventions: e.g., GitLab uses "!" for
+  merge requests and "#" for issues, while GitHub uses "#" for
+  everything.  By default these conventions are preserved.  For example,
+  setting ~forge-discussion~ to "@" displays GitHub discussions with an
+  at-sign prefix.
+
 - User Option: forge-buffer-draft-p ::
 
   This option controls whether new pull-requests start out as drafts

--- a/docs/forge.org
+++ b/docs/forge.org
@@ -1324,6 +1324,7 @@ then the remote is never removed.
     topic lists; elsewhere it expands to the empty string.
   - ~%s~ The slug of the topic (e.g., "#123"), padded to the width
     requested by the caller.
+  - ~%a~ The login of the topic's author.
   - ~%t~ The title of the topic.
 
 - User Option: forge-topic-slug-symbols ::

--- a/docs/forge.texi
+++ b/docs/forge.texi
@@ -1517,6 +1517,43 @@ This option specifies the width of repository slugs (i.e.,
 "OWNER/NAME").
 @end defopt
 
+@defopt forge-topic-line-format
+This option specifies the format for topic lines in topic and
+notification lists.
+
+The following @code{%}-sequences are supported:
+
+@itemize
+@item
+@code{%R} The slug of the repository, padded to
+@code{forge-topic-repository-slug-width}, followed by a space.  This is
+only non-empty in flat notification lists and in ungrouped, global
+topic lists; elsewhere it expands to the empty string.
+@item
+@code{%s} The slug of the topic (e.g., "#123"), padded to the width
+requested by the caller.
+@item
+@code{%t} The title of the topic.
+@end itemize
+@end defopt
+
+@defopt forge-topic-slug-symbols
+This option specifies the symbols used to prefix topic slugs, by
+topic type.
+
+Each entry maps a topic class (@code{forge-issue}, @code{forge-pullreq} or
+@code{forge-discussion}) to the symbol displayed in front of the topic's
+number.  When the symbol is @code{nil}, the slug provided by the forge is
+used as-is; otherwise the forge's leading symbol is replaced with the
+configured one at display time.
+
+Note that forges use their own conventions: e.g., GitLab uses "!" for
+merge requests and "#" for issues, while GitHub uses "#" for
+everything.  By default these conventions are preserved.  For example,
+setting @code{forge-discussion} to "@@" displays GitHub discussions with an
+at-sign prefix.
+@end defopt
+
 @defopt forge-buffer-draft-p
 This option controls whether new pull-requests start out as drafts
 by default.

--- a/docs/forge.texi
+++ b/docs/forge.texi
@@ -1533,6 +1533,8 @@ topic lists; elsewhere it expands to the empty string.
 @code{%s} The slug of the topic (e.g., "#123"), padded to the width
 requested by the caller.
 @item
+@code{%a} The login of the topic's author.
+@item
 @code{%t} The title of the topic.
 @end itemize
 @end defopt

--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -75,6 +75,7 @@ The following %-sequences are supported:
      empty string.
 `%s' The slug of the topic (e.g., \"#123\"), padded to the width
      requested by the caller.
+`%a' The login of the topic's author.
 `%t' The title of the topic."
   :package-version '(forge . "0.5.0")
   :group 'forge
@@ -955,7 +956,12 @@ can be selected from the start."
                              " "))
                 ""))
      (?s . ,(string-pad (forge--format-topic-slug topic) (or width 5)))
+     (?a . ,(forge--format-topic-author topic))
      (?t . ,(forge--format-topic-title topic)))))
+
+(defun forge--format-topic-author (topic)
+  (magit--propertize-face (or (oref topic author) "(ghost)")
+                          'forge-post-author))
 
 (defun forge--format-topic-slug (topic)
   (with-slots (slug state status saved-p) topic

--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -63,6 +63,47 @@ The following %-sequences are supported:
   :group 'forge
   :type 'string)
 
+(defcustom forge-topic-line-format "%R%s %t"
+  "Format for topic lines in topic and notification lists.
+
+The following %-sequences are supported:
+
+`%R' The slug of the repository, padded to
+     `forge-topic-repository-slug-width', followed by a space.
+     This is only non-empty in flat notification lists and in
+     ungrouped, global topic lists; elsewhere it expands to the
+     empty string.
+`%s' The slug of the topic (e.g., \"#123\"), padded to the width
+     requested by the caller.
+`%t' The title of the topic."
+  :package-version '(forge . "0.5.0")
+  :group 'forge
+  :type 'string)
+
+(defcustom forge-topic-slug-symbols
+  '((forge-issue      . nil)
+    (forge-pullreq    . nil)
+    (forge-discussion . nil))
+  "Symbols used to prefix topic slugs, by topic type.
+
+Each entry maps a topic class to the symbol displayed in front of
+the topic's number.  When the symbol is nil, the slug provided by
+the forge is used as-is; otherwise the forge's leading symbol is
+replaced with the configured one at display time.
+
+Note that forges use their own conventions: e.g., GitLab uses
+\"!\" for merge requests and \"#\" for issues, while GitHub uses
+\"#\" for everything.  By default these conventions are preserved.
+For example, setting `forge-discussion' to \"@\" displays GitHub
+discussions with an at-sign prefix."
+  :package-version '(forge . "0.5.0")
+  :group 'forge
+  :type '(alist :key-type (choice (const forge-issue)
+                                  (const forge-pullreq)
+                                  (const forge-discussion))
+                :value-type (choice (const :tag "Use forge's slug" nil)
+                                    string)))
+
 (defcustom forge-post-fill-region t
   "Whether to call `fill-region' before displaying forge posts."
   :package-version '(forge . "0.1.0")
@@ -900,25 +941,26 @@ can be selected from the start."
                  `(,@spec (?i . ,(oref topic number)))))
 
 (defun forge--format-topic-line (topic &optional width)
-  (concat
-   (and (or (and (derived-mode-p 'forge-notifications-mode)
-                 (eq forge-notifications-display-style 'flat))
-            (and (derived-mode-p 'forge-topics-mode)
-                 (oref forge--buffer-topics-spec global)
-                 (not (oref forge--buffer-topics-spec grouped))))
-        (concat (truncate-string-to-width
-                 (oref (forge-get-repository topic) slug)
-                 forge-topic-repository-slug-width
-                 nil ?\s t)
-                " "))
-   (string-pad (forge--format-topic-slug topic) (or width 5))
-   " "
-   (forge--format-topic-title topic)))
+  (format-spec
+   forge-topic-line-format
+   `((?R . ,(or (and (or (and (derived-mode-p 'forge-notifications-mode)
+                              (eq forge-notifications-display-style 'flat))
+                         (and (derived-mode-p 'forge-topics-mode)
+                              (oref forge--buffer-topics-spec global)
+                              (not (oref forge--buffer-topics-spec grouped))))
+                     (concat (truncate-string-to-width
+                              (oref (forge-get-repository topic) slug)
+                              forge-topic-repository-slug-width
+                              nil ?\s t)
+                             " "))
+                ""))
+     (?s . ,(string-pad (forge--format-topic-slug topic) (or width 5)))
+     (?t . ,(forge--format-topic-title topic)))))
 
 (defun forge--format-topic-slug (topic)
   (with-slots (slug state status saved-p) topic
     (magit--propertize-face
-     slug
+     (forge--apply-topic-slug-symbol topic slug)
      `(,@(and saved-p               '(forge-topic-slug-saved))
        ,@(and (eq status 'unread)   '(forge-topic-slug-unread))
        ,(pcase state
@@ -926,6 +968,20 @@ can be selected from the start."
           ((or 'completed 'merged)  'forge-topic-slug-completed)
           ((or 'unplanned 'outdated 'duplicate 'rejected)
            'forge-topic-slug-expunged))))))
+
+(defun forge--apply-topic-slug-symbol (topic slug)
+  "Return SLUG with its leading symbol replaced per `forge-topic-slug-symbols'.
+The replacement is chosen based on the type of TOPIC.  If no symbol is
+configured for that type, SLUG is returned unchanged."
+  (let ((symbol (cdr (assq (cond ((forge-discussion-p topic) 'forge-discussion)
+                                 ((forge-pullreq-p topic)    'forge-pullreq)
+                                 ((forge-issue-p topic)      'forge-issue))
+                           forge-topic-slug-symbols))))
+    (if symbol
+        (concat symbol (string-remove-prefix
+                        "@" (string-remove-prefix
+                             "!" (string-remove-prefix "#" slug))))
+      slug)))
 
 (defun forge--format-topic-refs (topic)
   (pcase-let


### PR DESCRIPTION
**Disclaimer:** this code was mostly generated by AI, I've carefully phrased the prompt to make sure it respects this repo's style and conventions.

# Add format line customization

Add the ability to customize the format of each `forge-topic` line. By default, everything behaves identically as before, but you now have 2 new options:

- `forge-topic-line-format`: define how a topic line should be displayed
- `forge-topic-slug-symbols`: define item symbols by type i.e Gitlab-style `#` for issues and `!` for pull requests, even on other forges

I've been using this daily for a week of work in `magit-status` and `forge-list-global-topics`, and found no issue yet.

Here's what it looks like for me with those settings:

```
      forge-topic-line-format "%R%5s %-15a %t"
      forge-topic-slug-symbols
      '((forge-issue . "#")
        (forge-pullreq . "!")
        (forge-discussion . "@"))
```

```
Pull requests (3)
  !4  dependabot      build(deps): bump actions/download-artifact from 4.1.8 to 8.0.1 dependencies github_actions
  !3  dependabot      build(deps): bump mozilla-actions/sccache-action from 0.0.9 to 0.0.10 dependencies github_actions
  !2  antoine-gauvain ci: add dependabot

Issues (1)
  #21 antoine-gauvain add github <> slack handle mapping generator
```