### PR TITLE
forge--pull-notifications: don't crash on HTTP-level GraphQL errors

### DIFF
--- a/lisp/forge-github.el
+++ b/lisp/forge-github.el
@@ -701,7 +701,8 @@
                    ;; have been disabled.  Drop them and try again.
                    (setq errorback
                          (lambda (errors _headers _status _req)
-                           (if (zerop tries)
+                           (if (or (zerop tries)
+                                   (not (eq (car-safe errors) 'errors)))
                                (ghub--signal-error errors)
                              (decf tries)
                              (cond-let


### PR DESCRIPTION
Fixes #859

When pulling notifications, the errorback for the batched topic queries assumes the failure is a GraphQL `errors` list and scans it for NOT_FOUND. When a batch instead fails at the HTTP level - e.g. 403 from a repo the token can't reach, or GitHub's secondary rate limit during a large pull - ghub passes a transport error `(error http NNN)`. Its cdr `(http NNN)` is not a list of alists, so the scan dies with "Wrong type argument: listp, http" inside the url process filter and the whole pull is aborted.

This guards the NOT_FOUND scan so it only runs on an actual GraphQL `errors` list; HTTP-level failures fall through to `ghub--signal-error`, same as other unrecoverable errors.

Disclosure: investigation was LLM-assisted, as noted in #859, which also includes a local workaround. That workaround skips the failed batch and keeps going (more functional for a big pull); this PR takes the more conservative path of just signaling the error. Both stop the crash.
