### PR TITLE
Use cached base ref after Pull Request is merged

### DIFF
--- a/lisp/forge-pullreq.el
+++ b/lisp/forge-pullreq.el
@@ -242,7 +242,8 @@ can be selected from the start."
 
 (defun forge--pullreq-range (pullreq &optional endpoints)
   (and-let ((head (forge--pullreq-ref pullreq)))
-    (concat (forge--get-remote) "/" (oref pullreq base-ref)
+    (concat (or (oref pullreq base-rev)
+                (concat (forge--get-remote) "/" (oref pullreq base-ref)))
             (if endpoints "..." "..")
             head)))
 


### PR DESCRIPTION
Previously, when viewing a pull request merged with a merge commit, Forge would fails to calculate a diff for the changes that were merged. This prevents quickly reviewing the diff of changes that were merged by pressing "d d" on the pull request, a common and helpful workflow.

The root issue appears to be that `forge--pullreq-range` used by the diff commands looks at the pull request's base branch name, and compares the pull request HEAD commit to the _current_ commit at the base branch. After the PR is merged, the merge commit will provide a common ancestor for both, leading to the empty diff.

This applies the same fix applied in commit a3cf64d to `forge--insert-pullreq-commits`, which uses the cached base ref retrieved from the server, which represents the commit at the base branch _at the time the PR was open_. This should produce consistent diffs that line up with the commits listed in the topic buffer.