### PR TITLE
forge-visit-topic-from-url: Visit any topic from configured forges, regardless of if it is in the database or the repo tracked

### DIFF
--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -1278,8 +1278,8 @@ upstream remote."
         (propertize (forge--scope 'url) 'face 'bold)))
      :format "%d")]
 
-   ;; Nothing to tracked.
-   [:if-not (##forge--scope 'topdir)
+   ;; Nothing to track.
+   [:if-not (##or (forge--scope 'topdir) (forge--scope 'repo))
     (:info*
      (lambda ()
        (format
@@ -1317,7 +1317,8 @@ upstream remote."
       (format
        (propertize "Adding %s to database," 'face 'transient-heading)
        (propertize (forge--scope 'url) 'face 'bold)))
-    ("r" forge-forge.remote :format " %k from %d %v," :face 'bold)
+    ("r" forge-forge.remote :if (##forge--scope 'wtree)
+     :format " %k from %d %v," :face 'bold)
     ("a" "pulling all topics"
      (lambda (repo)
        (interactive (list (forge--scope 'repo)))

--- a/lisp/forge-commands.el
+++ b/lisp/forge-commands.el
@@ -378,6 +378,7 @@ commit, and for a file."
       (and$ (magit-file-at-point)            (forge-get-url :blob nil $))
       (forge-post-at-point)
       (forge-current-topic)
+      (forge--loading-topic-url)
       (and (or magit-buffer-file-name
                buffer-file-name
                (derived-mode-p 'dired-mode))
@@ -559,11 +560,20 @@ lifts the limitation to active pull-requests."
   (if (string-match
        "/\\(issues\\|pull\\|discussions\\|merge_requests\\)/\\([0-9]+\\)\\'"
        url)
-      (forge-topic-setup-buffer
-       (forge-get-topic (forge-get-repository
-                         (substring url 0 (match-beginning 1))
-                         nil :tracked)
-                        (string-to-number (match-string 2 url))))
+      (let ((repo-url (substring url 0 (match-beginning 1)))
+            (number (string-to-number (match-string 2 url)))
+            (mode (pcase (match-string 1 url)
+                    ("issues"                     #'forge-issue-mode)
+                    ((or "pull" "merge_requests") #'forge-pullreq-mode)
+                    ("discussions"                #'forge-discussion-mode))))
+        (if-let ((repo (forge-get-repository repo-url nil :tracked?)))
+            (if-let ((topic (forge-get-topic repo number)))
+                (forge-topic-setup-buffer topic)
+              (forge-topic-setup-loading-buffer repo number mode))
+          ;; If the repo is not yet tracked, still set the placeholder
+          ;; buffer up with a stub.  It will prompt the user to track.
+          (forge-topic-setup-loading-buffer
+           (forge-get-repository repo-url nil :stub) number mode)))
     (user-error "Not recognized as a topic URL: %s" url)))
 
 ;;;###autoload
@@ -1356,9 +1366,15 @@ upstream remote."
      (when (eq limit :selective)
        (oset repo selective-p t)
        (setq limit nil))
-     (forge--pull repo
-                  (and (not (forge-get-worktree repo)) #'ignore)
-                  limit))))
+     (let ((in-loading-buffer (bound-and-true-p forge--loading-topic)))
+       (forge--pull repo
+                    (and (not (forge-get-worktree repo))
+                         (not in-loading-buffer)
+                         #'ignore)
+                    limit)
+       (when in-loading-buffer
+         (setq forge--loading-tracking-pull-status t)
+         (forge-refresh-buffer))))))
 
 (defun forge-add-repository--scope (&optional directory)
   (let* ((repo      (if directory

--- a/lisp/forge-github.el
+++ b/lisp/forge-github.el
@@ -45,7 +45,8 @@
    (blob-url-format            :initform "https://%h/%o/%n/blob/%r/%f")
    (create-issue-url-format    :initform "https://%h/%o/%n/issues/new")
    (create-pullreq-url-format  :initform "https://%h/%o/%n/compare")
-   (pullreq-refspec            :initform "+refs/pull/*/head:refs/pullreqs/*")))
+   (pullreq-refspec            :initform "+refs/pull/*/head:refs/pullreqs/*")
+   (pull-topic-by-number-p     :initform t)))
 
 ;;; Query
 
@@ -235,8 +236,8 @@
           (oset repo condition :tracked))
         (forge--msg repo t t   "Storing REPO")
         (cond
-          ((oref repo selective-p))
           (callback (funcall callback))
+          ((oref repo selective-p) (forge-refresh-buffer))
           ((forge--maybe-git-fetch repo buf))))
       :narrow '(repository)
       :until

--- a/lisp/forge-gitlab.el
+++ b/lisp/forge-gitlab.el
@@ -41,7 +41,8 @@
    (blob-url-format           :initform "https://%h/%o/%n/-/blob/%r/%f")
    (create-issue-url-format   :initform "https://%h/%o/%n/issues/new")
    (create-pullreq-url-format :initform "https://%h/%o/%n/merge_requests/new")
-   (pullreq-refspec :initform "+refs/merge-requests/*/head:refs/pullreqs/*")))
+   (pullreq-refspec :initform "+refs/merge-requests/*/head:refs/pullreqs/*")
+   (pull-topic-by-number-p :initform t)))
 
 ;;; Pull
 ;;;; Repository
@@ -89,8 +90,8 @@
                    (forge--update-pullreqs   repo .pullreqs)
                    (oset repo condition :tracked)))
                (forge--msg repo t t "Storing REPO")
-               (cond ((oref repo selective-p))
-                     (callback (funcall callback))
+               (cond (callback (funcall callback))
+                     ((oref repo selective-p) (forge-refresh-buffer))
                      ((forge--maybe-git-fetch repo buffer)))))))))
 
 (cl-defmethod forge--fetch-repository ((repo forge-gitlab-repository) callback)
@@ -121,6 +122,9 @@
 (cl-defmethod forge--pull-topic ((repo forge-gitlab-repository) _topic
                                  &key callback _errorback)
   (forge--pull repo callback)) ; TODO Pull only the one topic.
+
+(cl-defmethod forge--pull-topic ((repo forge-gitlab-repository) (_number number))
+  (forge--pull repo #'forge-refresh-buffer)) ; TODO Pull only the one topic.
 
 ;;;; Issues
 

--- a/lisp/forge-repo.el
+++ b/lisp/forge-repo.el
@@ -48,6 +48,7 @@
    (create-issue-url-format    :initform nil :allocation :class)
    (create-pullreq-url-format  :initform nil :allocation :class)
    (pullreq-refspec            :initform nil :allocation :class)
+   (pull-topic-by-number-p     :initform nil :allocation :class)
    (id                         :initform nil :initarg :id)
    (forge-id                   :initform nil :initarg :forge-id)
    (forge                      :initform nil :initarg :forge)

--- a/lisp/forge-topic.el
+++ b/lisp/forge-topic.el
@@ -34,6 +34,10 @@
 
 (defvar bug-reference-auto-setup-functions)
 
+;; Forward declarations for `forge--topic-continue-loabding'
+(declare-function forge-add-repository "forge-commands")
+(declare-function forge-get-url "forge-commands")
+
 (define-obsolete-face-alias 'forge-topic-slug-completed
                             'forge-topic-slug-realized "Forge 0.5.0")
 
@@ -1337,30 +1341,156 @@ This mode itself is never used directly."
     buffer))
 
 (defun forge-topic-refresh-buffer ()
-  (let ((topic (closql-reload forge-buffer-topic)))
-    (setq forge-buffer-topic topic)
-    (magit-set-header-line-format (forge--format-topic-line topic))
-    (magit-insert-section (topicbuf)
-      (magit-insert-headers
-       (pcase major-mode
-         ('forge-discussion-mode 'forge-discussion-headers-hook)
-         ('forge-issue-mode      'forge-issue-headers-hook)
-         ('forge-pullreq-mode    'forge-pullreq-headers-hook)))
-      (when (forge-pullreq-p topic)
-        (magit-insert-section (pullreq topic)
-          (magit-insert-heading "Commits")
-          (forge--insert-pullreq-commits topic t)))
-      (when-let ((note (oref topic note)))
-        (magit-insert-section (note)
-          (magit-insert-heading "Note")
-          (insert (forge--fontify-markdown note) "\n\n")))
-      (forge-insert-post topic nil)
-      (dolist (post (oref topic posts))
-        (forge-insert-post post topic))
-      (when (and (display-images-p)
-                 (fboundp 'markdown-display-inline-images))
-        (let ((markdown-display-remote-images t))
-          (markdown-display-inline-images))))))
+  ;; Topic buffer can be either a real topic buffer or a placeholder
+  ;; "loading" buffer.  If loading, `forge-buffer-topic' is unset.
+  (let* ((loaded forge-buffer-topic)
+         (result (if loaded
+                     (closql-reload forge-buffer-topic)
+                   (forge--topic-continue-loading))))
+    (cond
+     ;; Topic is loading: show a progress line
+     ((stringp result)
+      (pcase-let ((`(,repo ,number) forge--loading-topic))
+        (magit-set-header-line-format
+         (format "%s #%s" (oref repo slug) number)))
+      (magit-insert-section (topicbuf)
+        (insert (propertize result 'font-lock-face 'font-lock-comment-face))))
+     ;; Topic available: render it
+     (result
+      (let ((topic result))
+        (setq forge-buffer-topic topic)
+        (magit-set-header-line-format (forge--format-topic-line topic))
+        (magit-insert-section (topicbuf)
+          (magit-insert-headers
+           (pcase major-mode
+             ('forge-discussion-mode 'forge-discussion-headers-hook)
+             ('forge-issue-mode      'forge-issue-headers-hook)
+             ('forge-pullreq-mode    'forge-pullreq-headers-hook)))
+          (when (forge-pullreq-p topic)
+            (magit-insert-section (pullreq topic)
+              (magit-insert-heading "Commits")
+              (forge--insert-pullreq-commits topic t)))
+          (when-let ((note (oref topic note)))
+            (magit-insert-section (note)
+              (magit-insert-heading "Note")
+              (insert (forge--fontify-markdown note) "\n\n")))
+          (forge-insert-post topic nil)
+          (dolist (post (oref topic posts))
+            (forge-insert-post post topic))
+          (when (and (display-images-p)
+                     (fboundp 'markdown-display-inline-images))
+            (let ((markdown-display-remote-images t))
+              (markdown-display-inline-images)))))))))
+
+;;; Placeholder "loading" buffers
+
+(defvar-local forge--loading-topic nil
+  "In a placeholder topic buffer, the (REPO NUMBER) being fetched.")
+
+(defvar-local forge--loading-tracking-pull-status nil
+  "Non-nil if the buffer has started a pull to track a new repository.")
+
+(defvar-local forge--loading-topic-pull-status nil
+  "State of the topic pull operation in a placeholder topic buffer.
+If the topic has not been pulled, nil.  Set to t if the topic pull has
+begun, or `failed' if the pull completed without a result.")
+
+(defvar-local forge--loading-topic-git-fetch-process nil
+  "State of the pull request's ref fetch in a placeholder topic buffer.
+If no fetch operation has been started, nil.  Holds a reference to the
+fetch process if the fetch has begun.")
+
+(defun forge--fetch-pullreq-ref (repo number)
+  "Start a fetch of pull-request NUMBER's ref for REPO, if available.
+
+This launches an asynchronous git fetch for just the single ref for the
+individual pull request.  Returns the fetch process, or nil if there is
+nothing to fetch (no local worktree, etc.)."
+  (let* ((worktree (forge-get-worktree repo))
+         ;; REPO's `remote' slot is unset when it was looked up by URL,
+         ;; so resolve the remote name from the worktree's git config.
+         (default-directory (or worktree default-directory))
+         (refspec (oref repo pullreq-refspec))
+         (remote  (and worktree refspec (forge--get-remote))))
+    (and remote
+         (magit-git-fetch
+          remote (string-replace "*" (number-to-string number) refspec)))))
+
+(defun forge--topic-continue-loading ()
+  (pcase-let ((`(,repo ,number) forge--loading-topic))
+    (let ((tracked (forge-get-repository
+                    (list (oref repo forge) (oref repo owner) (oref repo name))
+                    nil :tracked?)))
+      (cond
+       ;; Repo not tracked: prompt the user to pull by calling
+       ;; `forge-add-repository'.
+       ((and (not tracked) (not forge--loading-tracking-pull-status))
+        (forge-add-repository (forge-get-url repo))
+        (format "%s is not tracked" (oref repo slug)))
+       ;; Tracking pull started: show progress
+       ((not tracked)
+        (format "Pulling %s..." (oref repo slug)))
+       ;; Topic not in database: pull the topic
+       ((null (forge-get-topic tracked number))
+        (cond
+         ;; Not started: start the pull.
+         ((memq forge--loading-topic-pull-status '(nil failed))
+          (setq forge--loading-topic-pull-status t)
+          (forge--pull-topic tracked number)
+          (format "Fetching #%s from %s..." number (oref repo slug)))
+         ;; Pull started, but still no topic: the topic likely didn't
+         ;; exist on the server.
+         (t
+          ;; TODO we are just assuming that the absence of a topic on
+          ;; the next refresh after we called pull means it doesn't
+          ;; exist.  In the future, forge should implement an error
+          ;; propagation mechanism a la `magit-this-error'.
+          (setq forge--loading-topic-pull-status 'failed)
+          (format "#%s not found in %s" number (oref repo slug)))))
+       ;; Topic loaded: For pull-requests, also fetch the git ref for
+       ;; the topic (and defer rendering until completion).
+       (t
+        (let ((topic (forge-get-topic tracked number))
+              (fetching nil))
+          (cond
+           ((processp forge--loading-topic-git-fetch-process)
+            (setq fetching (process-live-p forge--loading-topic-git-fetch-process)))
+           ((forge-pullreq-p topic)
+            (when-let ((process (forge--fetch-pullreq-ref tracked number)))
+              (setq forge--loading-topic-git-fetch-process process
+                    fetching t))))
+          (if fetching
+              (format "Fetching #%s from %s..." number (oref repo slug))
+            ;; Mark the topic as read before returning it, matching
+            ;; the flow in `forge-topic-setup-buffer'
+            (forge-topic-mark-read topic)
+            topic)))))))
+
+(defun forge--loading-topic-url ()
+  (and forge--loading-topic
+       ;; Take a best guess at the URL.  Obviously we don't yet know
+       ;; if the topic actually exists.
+       (pcase-let ((`(,repo ,number) forge--loading-topic))
+         (when-let ((slot (pcase major-mode
+                            ('forge-issue-mode      'issue-url-format)
+                            ('forge-pullreq-mode    'pullreq-url-format)
+                            ('forge-discussion-mode 'discussion-url-format))))
+           (forge--format repo slot `((?i . ,number)))))))
+
+(defun forge-topic-setup-loading-buffer (repo number mode)
+  (unless (oref repo pull-topic-by-number-p)
+    (user-error "Topic %s is not pulled, and fetching topic by number is not supported for the %s forge"
+                number (oref repo forge)))
+  (magit-setup-buffer mode t
+    :buffer (format "*forge: %s #%s*" (oref repo slug) number)
+    :directory (or (forge-get-worktree repo) "/")
+    (forge--loading-topic (list repo number))
+    ;; TODO performing the git fetch on a new pull request raises the
+    ;; magit status buffer in the window ordering when it is refreshed
+    ;; by the process sentinel.  We disable that behavior, but this
+    ;; should probably be more narrowly-scoped to only when we visit a
+    ;; topic buffer from somewhere outside of magit/forge.
+    (magit-refresh-status-buffer nil)))
 
 (defun forge-insert-post (post topic)
   (magit-insert-section (post post)
@@ -1413,7 +1543,12 @@ This mode itself is never used directly."
   (insert "\n\n"))
 
 (cl-defmethod magit-buffer-value (&context (major-mode forge-topic-mode))
-  (oref forge-buffer-topic slug))
+  ;; Topic buffer can be either a real topic buffer or a placeholder
+  ;; "loading" buffer.  If loading, `forge-buffer-topic' is unset.
+  (if forge-buffer-topic
+      (oref forge-buffer-topic slug)
+    (and forge--loading-topic
+         (format "#%s" (cadr forge--loading-topic)))))
 
 ;;; Bookmarks
 


### PR DESCRIPTION
This is the first part of a broader workflow I have been working on: a `browse-url` handler that allows intercepting links to `github.com` and other forges from gnus emails, Org-mode buffers (when the original link was captured without the use of `orgit-forge`), IRC chats, etc. and redirecting those to forge instead of the default browser.

This PR proposes an extension to `forge-visit-topic-from-url` that allows visiting any topic URL from a configured forge in `forge-alist`, regardless of it is already pulled. Essentially, it automates the workflow of trying to use the existing `forge-visit-topic-from-url`, encountering an error because the topic is not pulled (or repo not tracked), and then tracking down a subtitle magit buffer to do one or both of the prior. The proposal:

1. Does not change Forge's existing model of pulling topics into a local database
2. If the repository is already tracked and the topic exists in the database, `forge-visit-topic-from-url` behaves as before
3. If the topic does not already exist, a topic buffer is created in a new "loading" (or "stub") state
    - If the repository is not yet tracked, the `forge-add-repository` transient is automatically opened so the user can choose how to add the repository to the database
    - If the repository is tracked but the topic does not exist in the database, triggers an automatic `forge-pull-topic` to fetch the topic, then (if the topic is a pull request and the repository is associated with a local worktree) fetches the relevant git ref.
    - When loading is complete, the topic buffer automatically refreshes to display the topic.

The implementation of the "loading" topic buffer uses a simple state machine that advances by the existing automatic refresh of the buffer that occurs when the various magit/forge fetch commands complete.

In a second (standalone) commit, I made a few minor tweaks to the `forge-add-repository` UI to hide certain elements in the transient that are irrelevant to the flow of adding repositories by URL.

## Potential areas for improvement

In general, I think the implementation came out fairly clean, which hopefully means it can integrate without disrupting any of your longer-term plans for the package.

There are a few areas that could be improved over time or with a few broader architectural changes (I left most of these marked with TODO comments):
- Forge doesn't really have a good progress/error callback model, so I broke abstraction in one case (`forge-add-repository` sets a buffer-local status variable) and in the other case just had the state machine guess, in order to display some indication to the user of whether the topic is still loading or has stopped due to some error.
- GitLab doesn't support fetching a single topic at the moment, so I just stubbed out this method to the full topic fetch.
- `forge--fetch-pullreq-ref` seems like a useful workflow to generalize, maybe it should always be hooked into `forge-fetch-this-topic` so pressing G in an existing topic buffer both pulls the forge data and any updated git ref (which would be needed to display any new commits) in one go.

## Screenshots

Visiting a topic in a repo that is not yet tracked:
<img width="744" height="764" alt="Screenshot 2026-08-09 at 10 33 22 PM" src="https://github.com/user-attachments/assets/bc774af9-473a-4c65-9717-3f60b6c545fd" />

Fetching a topic not yet in the database:
<img width="744" height="764" alt="Screenshot 2026-08-09 at 10 34 59 PM" src="https://github.com/user-attachments/assets/39e227ad-13ef-4a60-a8a9-8892bb2cf0bd" />